### PR TITLE
🔒 Fix sensitive data logging in MagicLinkVerification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pspo",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pspo",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dependencies": {
         "@tanstack/match-sorter-utils": "^8.19.4",
         "@tanstack/react-query": "^5.90.20",

--- a/src/features/auth/components/MagicLinkVerification/MagicLinkVerification.test.tsx
+++ b/src/features/auth/components/MagicLinkVerification/MagicLinkVerification.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { MagicLinkVerification } from './MagicLinkVerification';
+import { authService } from '../../api/authService';
+import { BrowserRouter } from 'react-router-dom';
+
+// Mock dependencies
+vi.mock('../../api/authService', () => ({
+  authService: {
+    isMagicLink: vi.fn(),
+    completeMagicLinkSignIn: vi.fn(),
+  },
+}));
+
+vi.mock('react-toastify', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock react-router-dom
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+describe('MagicLinkVerification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should NOT log sensitive URL to console', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    (authService.isMagicLink as any).mockReturnValue(true);
+    (authService.completeMagicLinkSignIn as any).mockResolvedValue({
+      uid: 'test-uid',
+      email: 'test@example.com',
+    });
+
+    render(
+      <BrowserRouter>
+        <MagicLinkVerification />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      // Check that authService was called (to ensure the flow ran)
+      expect(authService.completeMagicLinkSignIn).toHaveBeenCalled();
+    });
+
+    // Check if console.log was NOT called with the sensitive message
+    expect(consoleSpy).not.toHaveBeenCalledWith('URL actuelle:', expect.any(String));
+
+    // Also check for user details logging
+    expect(consoleSpy).not.toHaveBeenCalledWith('User UID:', expect.any(String));
+    expect(consoleSpy).not.toHaveBeenCalledWith('User Email:', expect.any(String));
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/features/auth/components/MagicLinkVerification/MagicLinkVerification.tsx
+++ b/src/features/auth/components/MagicLinkVerification/MagicLinkVerification.tsx
@@ -36,9 +36,6 @@ export const MagicLinkVerification = () => {
 		setIsVerifying(true);
 		setError(null);
 
-		console.log('🔍 Vérification du Magic Link...');
-		console.log('URL actuelle:', window.location.href);
-
 		// Vérifier si c'est bien un Magic Link
 		if (!authService.isMagicLink()) {
 			console.error('❌ Ce n\'est pas un Magic Link valide');
@@ -47,13 +44,8 @@ export const MagicLinkVerification = () => {
 			return;
 		}
 
-		console.log('✅ Magic Link détecté');
-
 		try {
-			const user = await authService.completeMagicLinkSignIn(providedEmail);
-			console.log('✅ Connexion réussie !', user);
-			console.log('User UID:', user.uid);
-			console.log('User Email:', user.email);
+			await authService.completeMagicLinkSignIn(providedEmail);
 
 			toast.success('Connexion réussie !');
 
@@ -62,9 +54,7 @@ export const MagicLinkVerification = () => {
 				navigate('/'); // Rediriger vers la page d'accueil
 			}, 500);
 		} catch (error: any) {
-			console.error('❌ Erreur de vérification:', error);
-			console.error('Code d\'erreur:', error.code);
-			console.error('Message:', error.message);
+			console.error('❌ Erreur de vérification:', error.message);
 
 			if (error.message.includes('Email manquant')) {
 				setNeedsEmail(true);


### PR DESCRIPTION
This PR addresses a security vulnerability where the Magic Link URL (containing sensitive tokens) was being logged to the console.

**Changes:**
- Removed `console.log('URL actuelle:', window.location.href);` in `src/features/auth/components/MagicLinkVerification/MagicLinkVerification.tsx`.
- Removed other sensitive `console.log` statements in the same file.
- Added `src/features/auth/components/MagicLinkVerification/MagicLinkVerification.test.tsx` to verify that sensitive information is not logged.

**Verification:**
- Verified that the new test passes and confirms the absence of sensitive logs.
- Verified that all existing tests pass.

---
*PR created automatically by Jules for task [14481567089899062230](https://jules.google.com/task/14481567089899062230) started by @maarconte*