### PR TITLE
🧹 Improve Types in useFetchFirebase Hook

### DIFF
--- a/src/features/quiz/components/QuestionsLoader/QuestionsLoader.tsx
+++ b/src/features/quiz/components/QuestionsLoader/QuestionsLoader.tsx
@@ -4,6 +4,7 @@ import "react-toastify/dist/ReactToastify.css";
 
 import { useFetchFirebase } from "../../../../utils/hooks";
 import { useQuestionsStore } from "../../../../stores/useQuestionsStore";
+import { Question } from "../../../../utils/types";
 
 interface QuestionsLoaderProps {
   children: ReactNode;
@@ -16,7 +17,7 @@ interface QuestionsLoaderProps {
 const QuestionsLoader: FC<QuestionsLoaderProps> = ({ children }) => {
   const formation = useQuestionsStore((state) => state.formation);
 
-  const { data, isLoading, errorMessage, refetch } = useFetchFirebase("questions");
+  const { data, isLoading, errorMessage, refetch } = useFetchFirebase<Question>("questions");
 
   // Update loading state
   useEffect(() => {

--- a/src/utils/hooks/index.tsx
+++ b/src/utils/hooks/index.tsx
@@ -16,7 +16,7 @@ import { Firebase } from "../../firebase.js";
 
 const db = getFirestore(Firebase);
 
-export function useFetchFirebase(collectionName: string) {
+export function useFetchFirebase<T = any>(collectionName: string) {
   const queryKey = ["collection", collectionName];
 
   const {
@@ -29,7 +29,7 @@ export function useFetchFirebase(collectionName: string) {
     queryFn: async () => {
       const collectionDocs = collection(db, collectionName);
       const querySnapshot = await getDocs(collectionDocs);
-      const fetchedData: any[] = [];
+      const fetchedData: T[] = [];
 
       querySnapshot.forEach((doc) => {
         fetchedData.push({
@@ -37,7 +37,7 @@ export function useFetchFirebase(collectionName: string) {
           ...doc.data(),
           isFlagged: doc.data().isFlagged ?? false,
           comments: doc.data().comments ?? [],
-        });
+        } as unknown as T);
       });
       return fetchedData;
     },


### PR DESCRIPTION
This PR refactors `useFetchFirebase` to accept a generic type parameter, allowing consumers to specify the expected data structure. This improves type safety and readability. It also updates `QuestionsLoader` to utilize this new capability.

---
*PR created automatically by Jules for task [12197788004985757089](https://jules.google.com/task/12197788004985757089) started by @maarconte*