### PR TITLE
Fix: Remove localStorage usage for email persistence (PII)

### DIFF
--- a/src/features/auth/api/authService.test.ts
+++ b/src/features/auth/api/authService.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { authService } from './authService';
+import { sendSignInLinkToEmail, signInWithEmailLink, signOut } from 'firebase/auth';
+
+// Mock firebase/auth
+vi.mock('firebase/auth', () => ({
+	getAuth: vi.fn(),
+	sendSignInLinkToEmail: vi.fn(),
+	isSignInWithEmailLink: vi.fn(),
+	signInWithEmailLink: vi.fn(),
+	signOut: vi.fn(),
+}));
+
+// Mock the internal firebase config/auth export
+vi.mock('../../../lib/firebase', () => ({
+	auth: {},
+}));
+
+// Mock local storage
+const localStorageMock = (() => {
+	let store: Record<string, string> = {};
+	return {
+		getItem: vi.fn((key: string) => store[key] || null),
+		setItem: vi.fn((key: string, value: string) => {
+			store[key] = value.toString();
+		}),
+		removeItem: vi.fn((key: string) => {
+			delete store[key];
+		}),
+		clear: vi.fn(() => {
+			store = {};
+		}),
+	};
+})();
+
+Object.defineProperty(window, 'localStorage', {
+	value: localStorageMock,
+});
+
+describe('authService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		localStorageMock.clear();
+	});
+
+	describe('sendMagicLink', () => {
+		it('should send sign-in link and NOT store email in localStorage', async () => {
+			const email = 'test@example.com';
+			await authService.sendMagicLink(email);
+			expect(sendSignInLinkToEmail).toHaveBeenCalledWith(expect.anything(), email, expect.anything());
+			expect(localStorageMock.setItem).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('completeMagicLinkSignIn', () => {
+		it('should sign in with provided email', async () => {
+			const email = 'test@example.com';
+			// Mock successful sign in
+			(signInWithEmailLink as any).mockResolvedValue({ user: { email, uid: '123' } });
+
+			await authService.completeMagicLinkSignIn(email);
+			expect(signInWithEmailLink).toHaveBeenCalledWith(expect.anything(), email, expect.anything());
+			// It should not try to access localStorage
+			expect(localStorageMock.getItem).not.toHaveBeenCalled();
+			expect(localStorageMock.removeItem).not.toHaveBeenCalled();
+		});
+
+		it('should throw error if email is missing (empty string)', async () => {
+			await expect(authService.completeMagicLinkSignIn('')).rejects.toThrow('Email manquant');
+			expect(localStorageMock.getItem).not.toHaveBeenCalled();
+		});
+
+		it('should throw error if email is missing (undefined via cast)', async () => {
+			await expect(authService.completeMagicLinkSignIn(undefined as any)).rejects.toThrow('Email manquant');
+			expect(localStorageMock.getItem).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('signOut', () => {
+		it('should sign out and NOT try to remove email from localStorage', async () => {
+			await authService.signOut();
+			expect(signOut).toHaveBeenCalled();
+			expect(localStorageMock.removeItem).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/features/auth/api/authService.ts
+++ b/src/features/auth/api/authService.ts
@@ -31,8 +31,7 @@ export const authService = {
 
 		try {
 			await sendSignInLinkToEmail(auth, email, actionCodeSettings);
-			// Sauvegarder l'email localement pour compléter la connexion
-			window.localStorage.setItem('emailForSignIn', email);
+			// Note: On ne sauvegarde plus l'email localement pour des raisons de sécurité (PII dans localStorage)
 		} catch (error: any) {
 			console.error('Erreur lors de l\'envoi du Magic Link:', error);
 			throw new Error(error.message || 'Échec de l\'envoi du lien de connexion');
@@ -49,25 +48,17 @@ export const authService = {
 
 	/**
 	 * Complète la connexion avec le Magic Link
-	 * @param email - Email de l'utilisateur (optionnel si sauvegardé)
+	 * @param email - Email de l'utilisateur
 	 * @returns Promise<User>
 	 * @throws Error si le lien est invalide ou expiré
 	 */
-	completeMagicLinkSignIn: async (email?: string): Promise<User> => {
-		// Récupérer l'email sauvegardé si non fourni
-		let userEmail = email;
-		if (!userEmail) {
-			userEmail = window.localStorage.getItem('emailForSignIn') || undefined;
-		}
-
-		if (!userEmail) {
+	completeMagicLinkSignIn: async (email: string): Promise<User> => {
+		if (!email) {
 			throw new Error('Email manquant. Veuillez saisir votre adresse email.');
 		}
 
 		try {
-			const result = await signInWithEmailLink(auth, userEmail, window.location.href);
-			// Nettoyer l'email sauvegardé
-			window.localStorage.removeItem('emailForSignIn');
+			const result = await signInWithEmailLink(auth, email, window.location.href);
 			return result.user;
 		} catch (error: any) {
 			console.error('Erreur lors de la vérification du Magic Link:', error);
@@ -88,8 +79,6 @@ export const authService = {
 	 */
 	signOut: async (): Promise<void> => {
 		await firebaseSignOut(auth);
-		// Nettoyer l'email sauvegardé au cas où
-		window.localStorage.removeItem('emailForSignIn');
 	},
 
 	/**
@@ -98,12 +87,4 @@ export const authService = {
 	getCurrentUser: (): User | null => {
 		return auth.currentUser;
 	},
-
-	/**
-	 * Récupère l'email sauvegardé pour la connexion
-	 */
-	getSavedEmail: (): string | null => {
-		return window.localStorage.getItem('emailForSignIn');
-	},
 };
-

--- a/src/features/auth/components/MagicLinkVerification/MagicLinkVerification.tsx
+++ b/src/features/auth/components/MagicLinkVerification/MagicLinkVerification.tsx
@@ -50,6 +50,10 @@ export const MagicLinkVerification = () => {
 		console.log('✅ Magic Link détecté');
 
 		try {
+			if (!providedEmail) {
+				throw new Error('Email manquant. Veuillez saisir votre adresse email.');
+			}
+
 			const user = await authService.completeMagicLinkSignIn(providedEmail);
 			console.log('✅ Connexion réussie !', user);
 			console.log('User UID:', user.uid);


### PR DESCRIPTION
This PR addresses a security vulnerability where the user's email address was stored in `localStorage` during the magic link authentication flow. This is considered unsafe as `localStorage` is accessible to XSS attacks.

**Changes:**
1.  Removed all `localStorage` interactions in `authService.ts`.
2.  Updated `completeMagicLinkSignIn` to require the `email` argument, ensuring type safety and explicit dependency injection.
3.  Updated `MagicLinkVerification.tsx` to check for email presence before calling the service, maintaining the existing user flow (prompting for email if missing).
4.  Added unit tests in `authService.test.ts` to verify the fix and ensure no regressions.
5.  Verified that `dist/` and `package-lock.json` are not included in the commit to keep the history clean.

**Verification:**
-   `npm test` passes all tests including the new ones.
-   `npm run build` succeeds.

---
*PR created automatically by Jules for task [980992955488609501](https://jules.google.com/task/980992955488609501) started by @maarconte*