### PR TITLE
🧹 Improve Types in Table.types.ts

### DIFF
--- a/src/features/admin/components/TableQuestions/TableQuestions.tsx
+++ b/src/features/admin/components/TableQuestions/TableQuestions.tsx
@@ -303,7 +303,6 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
     <div className="TableQuestions">
       <Table
         data={table}
-        columns={columns}
         selectedQuestion={selectedQuestion}
         selectedQuestions={selectedQuestions}
         setSelectedQuestion={setSelectedQuestion}

--- a/src/ui/Table/Table.tsx
+++ b/src/ui/Table/Table.tsx
@@ -57,7 +57,6 @@ const Filter: FC<FilterProps> = ({
 
 const Table: FC<TableProps> = ({
   data,
-  columns,
   selectedQuestions,
   setSelectedQuestions,
   setSelectedQuestion,

--- a/src/ui/Table/Table.types.ts
+++ b/src/ui/Table/Table.types.ts
@@ -1,8 +1,8 @@
+import { Table as TanStackTable } from "@tanstack/react-table";
 import { Question } from "../../utils/types";
 
 export interface TableProps {
-  data: any;
-  columns: any;
+  data: TanStackTable<Question>;
   selectedQuestions?: Question[];
   selectedQuestion?: Question;
   setSelectedQuestions?: React.Dispatch<React.SetStateAction<Question[]>>;


### PR DESCRIPTION
This PR addresses a code health issue in `src/ui/Table/Table.types.ts` where generic `any` types were used.

Changes:
1.  **Refactored `TableProps`**:
    *   Replaced `data: any` with `data: TanStackTable<Question>`.
    *   Removed `columns: any` as it was unused by the `Table` component (the table instance `data` already contains column definitions).
2.  **Cleaned up `Table.tsx`**:
    *   Removed unused `columns` prop from the component implementation.
3.  **Updated Usage**:
    *   Updated `TableQuestions.tsx` to stop passing the unused `columns` prop.

Verification:
*   Ran `bun run build` to verify type safety and build integrity.
*   Ran `bun run test` to ensure no regressions (20 tests passed).
*   Verified that `Table` component logic remains unchanged, only types and unused props were modified.


---
*PR created automatically by Jules for task [13939859041132161794](https://jules.google.com/task/13939859041132161794) started by @maarconte*