### PR TITLE
⚡ Bolt: Memoize TableQuestions columns

### DIFF
--- a/src/features/admin/components/TableQuestions/TableQuestions.tsx
+++ b/src/features/admin/components/TableQuestions/TableQuestions.tsx
@@ -14,7 +14,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { RankingInfo, rankItem } from "@tanstack/match-sorter-utils";
-import { FC, useEffect, useMemo, useState } from "react";
+import { FC, useEffect, useMemo, useState, useCallback } from "react";
 import { Trash2, XCircle, CheckSquare, X, Edit, ToggleRight, Circle } from "lucide-react";
 import { formatTimestamp, useDeleteDoc } from "../../../../utils/hooks";
 
@@ -82,7 +82,13 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
   const [isSelectNone, setIsSelectNone] = useState(false);
   const { handleDelete } = useDeleteDoc("questions");
 
-  const columns = [
+  // select question
+  const handleSelectQuestion = useCallback((question: Question) => {
+    setSelectedQuestion(question);
+    setIsModalOpen(true);
+  }, []);
+
+  const columns = useMemo(() => [
     {
       // column for the checkbox to multiselect
       header: "",
@@ -242,13 +248,7 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
       ),
       enableColumnFilter: false,
     },
-  ];
-
-  // select question
-  const handleSelectQuestion = (question: Question) => {
-    setSelectedQuestion(question);
-    setIsModalOpen(true);
-  };
+  ], [selectedQuestions, handleSelectQuestion]);
 
   // Pagination
   const [{ pageIndex, pageSize }, setPagination] = useState({


### PR DESCRIPTION
⚡ Bolt: Memoize TableQuestions columns

💡 What:
Wrapped `columns` definition in `useMemo` and `handleSelectQuestion` in `useCallback` in `src/features/admin/components/TableQuestions/TableQuestions.tsx`.

🎯 Why:
The `columns` array was being recreated on every render. Since `useReactTable` relies on stable column definitions to avoid full table re-initialization, this was causing unnecessary processing and re-renders, especially when state changed frequently (like typing in the global filter search box).

📊 Impact:
- Reduces re-renders and table processing overhead during filter/search operations.
- Improves rendering performance of the Questions table.

 microscop Measurement:
- Verified that `npm run build` passes.
- Verified that `npm test` passes (no regressions).
- Verified code structure manually.

---
*PR created automatically by Jules for task [3496556506181972725](https://jules.google.com/task/3496556506181972725) started by @maarconte*