### PR TITLE
🧹 Fix file input value not resetting after upload

### DIFF
--- a/src/ui/FileUploader/FileUploader.test.tsx
+++ b/src/ui/FileUploader/FileUploader.test.tsx
@@ -25,4 +25,26 @@ describe('FileUploader', () => {
       expect(handleFileMock).toHaveBeenCalledWith(file);
     }
   });
+
+  it('resets input value after file selection', () => {
+    const handleFileMock = vi.fn();
+    const { container } = render(<FileUploader handleFile={handleFileMock} />);
+
+    const file = new File(['dummy content'], 'test.csv', { type: 'text/csv' });
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    expect(input).toBeInTheDocument();
+
+    if (input) {
+      // Simulate browser setting the value
+      Object.defineProperty(input, 'value', {
+        value: 'C:\\fakepath\\test.csv',
+        writable: true,
+      });
+
+      fireEvent.change(input, { target: { files: [file] } });
+      expect(handleFileMock).toHaveBeenCalledTimes(1);
+      expect(input.value).toBe('');
+    }
+  });
 });

--- a/src/ui/FileUploader/FileUploader.tsx
+++ b/src/ui/FileUploader/FileUploader.tsx
@@ -27,6 +27,7 @@ const FileUploader = ({ handleFile }: FileUploaderProps) => {
 
     const fileUploaded = event.target.files[0];
     handleFile(fileUploaded);
+    event.target.value = '';
   };
   return (
     <>


### PR DESCRIPTION
This PR fixes an issue where the file input value was not being reset after a file was selected. This prevented users from re-selecting the same file if they needed to (e.g., after deleting it or if the upload failed and they wanted to try again without refreshing).

Changes:
- Modified `src/ui/FileUploader/FileUploader.tsx` to set `event.target.value = ''` in the `handleChange` handler.
- Added a regression test in `src/ui/FileUploader/FileUploader.test.tsx` to verify that the input value is correctly reset.


---
*PR created automatically by Jules for task [9182532759207579796](https://jules.google.com/task/9182532759207579796) started by @maarconte*