### PR TITLE
Configure admin email in setAdmin script

### DIFF
--- a/src/scripts/setAdmin.cjs
+++ b/src/scripts/setAdmin.cjs
@@ -1,18 +1,12 @@
 const admin = require('firebase-admin');
 const serviceAccount = require('./serviceAccountKey.json');
 
-// Get user email from command line arguments
-const userEmail = process.argv[2];
-
-if (!userEmail) {
-  console.error('Please provide an email address as an argument.');
-  console.error('Usage: node setAdmin.cjs <email>');
-  process.exit(1);
-}
-
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount)
 });
+
+// Remplacer par l'email de l'utilisateur à promouvoir admin
+const userEmail = "adrien.coudron@gmail.com";
 
 admin.auth().getUserByEmail(userEmail)
   .then(user => {


### PR DESCRIPTION
Updated `src/scripts/setAdmin.cjs` to use a hardcoded email address ('adrien.coudron@gmail.com') for promoting a user to admin, as requested. Removed the command-line argument handling to match the provided context and requirements.

---
*PR created automatically by Jules for task [4855192053258663942](https://jules.google.com/task/4855192053258663942) started by @maarconte*