### PR TITLE
Refactor TableActions bulk add logic

### DIFF
--- a/src/ui/Table/TableActions/TableActions.test.tsx
+++ b/src/ui/Table/TableActions/TableActions.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import TableActions from "./TableActions";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Papa from "papaparse";
+import { toast } from "react-toastify";
+
+// Mock dependencies
+const mockHandleAdd = vi.fn();
+const mockHandleDelete = vi.fn();
+const mockRefetch = vi.fn();
+
+vi.mock("../../../utils/hooks", () => ({
+  useAddDoc: () => ({
+    handleAdd: mockHandleAdd,
+  }),
+  useDeleteDoc: () => ({
+    handleDelete: mockHandleDelete,
+  }),
+}));
+
+vi.mock("../../../stores/useQuestionsStore", () => ({
+  useQuestionsStore: () => ({
+    questions: [],
+    refetch: mockRefetch,
+  }),
+}));
+
+vi.mock("papaparse", () => ({
+  default: {
+    parse: vi.fn(),
+  },
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock FileUploader component since we only need to trigger handleFile
+vi.mock("../../FileUploader", () => ({
+  default: ({ handleFile }: { handleFile: (file: any) => void }) => (
+    <button
+      data-testid="mock-file-uploader"
+      onClick={() => handleFile(new File(["content"], "test.csv"))}
+    >
+      Upload
+    </button>
+  ),
+}));
+
+// Mock ModalEditQuestion
+vi.mock("../../../features/admin/components/ModalEditQuestion/ModalEditQuestion", () => ({
+  default: () => <div data-testid="modal-edit-question" />,
+}));
+
+// Mock Modal
+vi.mock("../../Modal", () => ({
+  default: () => <div data-testid="modal" />,
+}));
+
+describe("TableActions", () => {
+  const defaultProps = {
+    selectedQuestions: [],
+    setSelectedQuestions: vi.fn(),
+    setIsSelectAll: vi.fn(),
+    setIsSelectNone: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should add all questions from CSV and wait for completion", async () => {
+    // Mock Papa.parse to return data immediately
+    (Papa.parse as any).mockImplementation((file: any, config: any) => {
+      config.complete({
+        data: [
+          { question: "Q1", answer: "A1", answerType: "S" },
+          { question: "Q2", answer: "A2", answerType: "S" },
+        ],
+      });
+    });
+
+    // Mock handleAdd with delay
+    mockHandleAdd.mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 100));
+      return {};
+    });
+
+    render(<TableActions {...defaultProps} />);
+
+    // Simulate file upload
+    fireEvent.click(screen.getByTestId("mock-file-uploader"));
+
+    // Check if "Add 2 questions" button appears
+    await waitFor(() => {
+      expect(screen.getByText("Add 2 questions")).toBeInTheDocument();
+    });
+
+    // Click "Add 2 questions"
+    fireEvent.click(screen.getByText("Add 2 questions"));
+
+    // Verify handleAdd is called immediately (synchronously in loop)
+    expect(mockHandleAdd).toHaveBeenCalledTimes(2);
+
+    // Verify toast is NOT called immediately (this should FAIL with current code)
+    expect(toast.success).not.toHaveBeenCalled();
+
+    // Wait for completion
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("The questions have been added");
+    });
+  });
+});

--- a/src/ui/Table/TableActions/TableActions.tsx
+++ b/src/ui/Table/TableActions/TableActions.tsx
@@ -98,13 +98,12 @@ const TableActions: React.FC<TableActionsProps> = ({
     }
   };
 
-  const addAllQuestions = () => {
+  const addAllQuestions = async () => {
     if (!csvData) return;
     try {
-      csvData?.forEach((question) => {
-        handleAdd(question);
-        setCsvData([]);
-      });
+      const promises = csvData.map((question) => handleAdd(question));
+      await Promise.all(promises);
+      setCsvData([]);
       toast.success("The questions have been added");
     } catch (error) {
       toast.error(


### PR DESCRIPTION
Refactored `addAllQuestions` in `src/ui/Table/TableActions/TableActions.tsx` to fix an issue where state was updated inside a loop and async operations were not awaited.

**Changes:**
- `addAllQuestions` is now `async`.
- Uses `Promise.all` to await all `handleAdd` calls concurrently.
- Calls `setCsvData([])` and `toast.success` only after all promises resolve.
- Added `src/ui/Table/TableActions/TableActions.test.tsx` to verify the fix and prevent regressions.

**Verification:**
- Ran `npx vitest src/ui/Table/TableActions/TableActions.test.tsx` which confirmed the fix (and failed with the old code).
- Ran all tests with `npx vitest run` and they passed.
- Ran `npx tsc --noEmit` to ensure type safety.

---
*PR created automatically by Jules for task [14111389356560178829](https://jules.google.com/task/14111389356560178829) started by @maarconte*