### PR TITLE
Refactor useUsers hook to use useFetchFirebase

### DIFF
--- a/src/features/auth/hooks/useUsers.test.tsx
+++ b/src/features/auth/hooks/useUsers.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useUsers } from './useUsers';
+import { ReactNode } from 'react';
+
+// Mock Firestore
+vi.mock('firebase/firestore', () => ({
+  getFirestore: vi.fn(() => ({})),
+  collection: vi.fn(),
+  getDocs: vi.fn(),
+  getDoc: vi.fn(),
+}));
+
+// Mock firebase app and db
+vi.mock('../../../lib/firebase', () => ({
+    db: {}
+}));
+vi.mock('../../../firebase.js', () => ({
+    Firebase: {},
+    db: {}
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe('useUsers', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should fetch and format users', async () => {
+        const mockDate = new Date('2023-01-01T00:00:00.000Z');
+        const mockTimestamp = { toDate: () => mockDate, seconds: mockDate.getTime() / 1000 };
+
+        const mockData = [
+            {
+                id: 'user1',
+                data: () => ({
+                    email: 'test@example.com',
+                    role: 'admin',
+                    createdAt: mockTimestamp,
+                    updatedAt: mockTimestamp
+                })
+            },
+            {
+                id: 'user2',
+                data: () => ({
+                    email: 'user2@example.com',
+                    // no role, should default to client
+                    // no dates
+                })
+            }
+        ];
+
+        const { getDocs } = await import('firebase/firestore');
+        vi.mocked(getDocs).mockResolvedValue({
+            docs: mockData,
+            forEach: (callback: any) => mockData.forEach(callback)
+        } as any);
+
+        const { result } = renderHook(() => useUsers(), { wrapper: createWrapper() });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.users).toHaveLength(2);
+
+        const user1 = result.current.users.find(u => u.uid === 'user1');
+        expect(user1).toBeDefined();
+        expect(user1?.email).toBe('test@example.com');
+        expect(user1?.role).toBe('admin');
+        expect(user1?.createdAt).toEqual(mockDate);
+
+        const user2 = result.current.users.find(u => u.uid === 'user2');
+        expect(user2).toBeDefined();
+        expect(user2?.email).toBe('user2@example.com');
+        expect(user2?.role).toBe('client'); // default
+        expect(user2?.createdAt).toBeUndefined();
+    });
+
+    it('should handle errors', async () => {
+        const { getDocs } = await import('firebase/firestore');
+        vi.mocked(getDocs).mockRejectedValue(new Error('Firestore error'));
+
+        const { result } = renderHook(() => useUsers(), { wrapper: createWrapper() });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.error).toBeTruthy();
+        // The error message might differ slightly between implementations, but let's check it's not null
+    });
+});

--- a/src/features/auth/hooks/useUsers.ts
+++ b/src/features/auth/hooks/useUsers.ts
@@ -1,6 +1,5 @@
-import { useState, useEffect } from 'react';
-import { collection, getDocs } from 'firebase/firestore';
-import { db } from '../../../lib/firebase';
+import { useMemo } from 'react';
+import { useFetchFirebase } from '../../../utils/hooks';
 import { UserRole } from '../types/roles.types';
 
 export interface UserData {
@@ -11,51 +10,37 @@ export interface UserData {
 	updatedAt?: Date;
 }
 
+interface RawUserData {
+	id: string;
+	email?: string;
+	role?: UserRole;
+	createdAt?: any;
+	updatedAt?: any;
+	[key: string]: any;
+}
+
 /**
  * Hook pour récupérer la liste de tous les utilisateurs
  * Réservé aux utilisateurs dev
  */
 export const useUsers = () => {
-	const [users, setUsers] = useState<UserData[]>([]);
-	const [loading, setLoading] = useState(true);
-	const [error, setError] = useState<string | null>(null);
+	const { data, isLoading, errorMessage, refetch } = useFetchFirebase<RawUserData>('users');
 
-	const fetchUsers = async () => {
-		setLoading(true);
-		setError(null);
-
-		try {
-			const usersCollection = collection(db, 'users');
-			const usersSnapshot = await getDocs(usersCollection);
-
-			const usersData: UserData[] = usersSnapshot.docs.map(doc => {
-				const data = doc.data();
-				return {
-					uid: doc.id,
-					email: data.email || '',
-					role: data.role || 'client',
-					createdAt: data.createdAt?.toDate(),
-					updatedAt: data.updatedAt?.toDate(),
-				};
-			});
-
-			setUsers(usersData);
-		} catch (err: any) {
-			console.error('Erreur lors de la récupération des utilisateurs:', err);
-			setError(err.message || 'Échec de la récupération des utilisateurs');
-		} finally {
-			setLoading(false);
-		}
-	};
-
-	useEffect(() => {
-		fetchUsers();
-	}, []);
+	const users: UserData[] = useMemo(() => {
+		if (!data) return [];
+		return data.map((user) => ({
+			uid: user.id,
+			email: user.email || '',
+			role: user.role || 'client',
+			createdAt: user.createdAt?.toDate ? user.createdAt.toDate() : user.createdAt,
+			updatedAt: user.updatedAt?.toDate ? user.updatedAt.toDate() : user.updatedAt,
+		}));
+	}, [data]);
 
 	return {
 		users,
-		loading,
-		error,
-		refetch: fetchUsers,
+		loading: isLoading,
+		error: errorMessage || null,
+		refetch,
 	};
 };


### PR DESCRIPTION
Refactored `useUsers` hook to utilize the standard `useFetchFirebase` hook, replacing manual Firestore `getDocs` calls and local state management. This improves consistency across the codebase and centralizes data fetching logic. Added comprehensive unit tests in `useUsers.test.tsx` to ensure correct data transformation (including timestamp conversion) and error handling. Verified that existing functionality is preserved and no regressions were introduced.

---
*PR created automatically by Jules for task [8592168605840671742](https://jules.google.com/task/8592168605840671742) started by @maarconte*