### PR TITLE
🧹 Refactor Table to separate action bar from column filters

### DIFF
--- a/src/ui/Table/Table.test.tsx
+++ b/src/ui/Table/Table.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Table from './Table';
+import { getCoreRowModel, useReactTable, getFilteredRowModel, ColumnDef } from '@tanstack/react-table';
+import { Question } from '../../utils/types';
+
+// Mock TableActions to check rendering count
+vi.mock('./TableActions/TableActions', () => ({
+  default: () => <div data-testid="table-actions">Table Actions</div>,
+}));
+
+// Mock TableSearch to check rendering count
+vi.mock('./TableSearch', () => ({
+  default: () => <div data-testid="table-search">Table Search</div>,
+}));
+
+// Mock Lucide icons
+vi.mock('lucide-react', () => ({
+  ChevronUp: () => <span>Up</span>,
+  ChevronDown: () => <span>Down</span>,
+  Trash2: () => <span>Trash</span>,
+  Plus: () => <span>Plus</span>,
+}));
+
+// Mock Pagination
+vi.mock('./Pagination/Pagination', () => ({
+    default: () => <div>Pagination</div>
+}));
+
+const TestTable = () => {
+    const data: Question[] = [
+        { id: '1', question: 'q1', answer: 'a1', category: 'c1' } as any,
+    ];
+
+    const columns: ColumnDef<Question>[] = [
+        {
+            accessorKey: 'question',
+            header: 'Question',
+            enableColumnFilter: true,
+        },
+        {
+            accessorKey: 'category',
+            header: 'Category',
+            enableColumnFilter: true,
+        }
+    ];
+
+    const table = useReactTable({
+        data,
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+    });
+
+    return <Table data={table} />;
+}
+
+describe('Table Component', () => {
+    it('renders TableActions only once even with multiple filterable columns', () => {
+        render(<TestTable />);
+
+        // This will find all instances of TableActions
+        const actions = screen.getAllByTestId('table-actions');
+
+        // With current buggy code, this should fail (it will likely be 2)
+        // We assert 1 because that's the desired state.
+        expect(actions).toHaveLength(1);
+    });
+
+    it('renders TableSearch for each filterable column', () => {
+        render(<TestTable />);
+        const searches = screen.getAllByTestId('table-search');
+        expect(searches).toHaveLength(2);
+    });
+});

--- a/src/ui/Table/Table.tsx
+++ b/src/ui/Table/Table.tsx
@@ -12,44 +12,19 @@ import { TableProps } from "./Table.types";
 import TableSearch from "./TableSearch";
 
 // Déplacer la définition du composant Filter et de son interface de props en dehors du composant Table
-interface FilterProps {
+interface ColumnFilterProps {
   column: Column<any, unknown>;
-  selectedQuestions: Question[];
-  setSelectedQuestions?: React.Dispatch<React.SetStateAction<Question[]>>;
-  setSelectedQuestion?: React.Dispatch<
-    React.SetStateAction<Question | undefined>
-  >;
-  setIsSelectAll?: React.Dispatch<React.SetStateAction<boolean>>;
-  setIsSelectNone?: React.Dispatch<React.SetStateAction<boolean>>;
-  selectedQuestion?: Question;
 }
 
-const Filter: FC<FilterProps> = ({
-  column,
-  selectedQuestions,
-  setSelectedQuestions,
-  setSelectedQuestion,
-  setIsSelectAll,
-  setIsSelectNone,
-  selectedQuestion,
-}) => {
+const ColumnFilter: FC<ColumnFilterProps> = ({ column }) => {
   const columnFilterValue = column.getFilterValue();
 
   return (
-    <div className="d-flex gap-1 w-100 justify-content-between">
-      <TableActions
-        selectedQuestions={selectedQuestions}
-        setSelectedQuestions={setSelectedQuestions ?? (() => {})}
-        setSelectedQuestion={setSelectedQuestion ?? (() => {})}
-        setIsSelectAll={setIsSelectAll ?? (() => {})}
-        setIsSelectNone={setIsSelectNone ?? (() => {})}
-        selectedQuestion={selectedQuestion}
-      />
+    <div className="d-flex gap-1 justify-content-end">
       <TableSearch
         value={(columnFilterValue ?? "") as string}
         onChange={column.setFilterValue}
-        // Pour le problème d'accessibilité, envisagez d'ajouter un id unique ici :
-        // inputId={`search-${column.id}`}
+        id={`search-${column.id}`}
       />
     </div>
   );
@@ -66,25 +41,29 @@ const Table: FC<TableProps> = ({
 }) => {
   return (
     <div className="Table">
-      {data.getHeaderGroups().map((headerGroup: any) => (
-        <div key={headerGroup.id}>
-          {headerGroup.headers
-            .filter((header: any) => header.column.getCanFilter())
-            .map((header: any) => (
-              <div key={header.id}>
-                <Filter
-                  column={header.column}
-                  selectedQuestions={selectedQuestions ?? []}
-                  setSelectedQuestions={setSelectedQuestions}
-                  setSelectedQuestion={setSelectedQuestion}
-                  setIsSelectAll={setIsSelectAll}
-                  setIsSelectNone={setIsSelectNone}
-                  selectedQuestion={selectedQuestion}
-                />
-              </div>
-            ))}
+      <div className="d-flex justify-content-between align-items-start mb-3">
+        <TableActions
+          selectedQuestions={selectedQuestions ?? []}
+          setSelectedQuestions={setSelectedQuestions ?? (() => {})}
+          setSelectedQuestion={setSelectedQuestion ?? (() => {})}
+          setIsSelectAll={setIsSelectAll ?? (() => {})}
+          setIsSelectNone={setIsSelectNone ?? (() => {})}
+          selectedQuestion={selectedQuestion}
+        />
+        <div className="d-flex flex-column gap-2">
+          {data.getHeaderGroups().map((headerGroup: any) => (
+            <div key={headerGroup.id}>
+              {headerGroup.headers
+                .filter((header: any) => header.column.getCanFilter())
+                .map((header: any) => (
+                  <div key={header.id}>
+                    <ColumnFilter column={header.column} />
+                  </div>
+                ))}
+            </div>
+          ))}
         </div>
-      ))}
+      </div>
       <table>
         <thead>
           {data.getHeaderGroups().map((headerGroup: any) => (

--- a/src/ui/Table/TableSearch/TableSearch.tsx
+++ b/src/ui/Table/TableSearch/TableSearch.tsx
@@ -9,6 +9,7 @@ import { TableSearchProps } from "./TableSearch.types";
 const TableSearch: FC<TableSearchProps> = ({
   value: initialValue,
   onChange,
+  id,
 }) => {
   const [value, setValue] = useState(initialValue);
   useEffect(() => {
@@ -34,7 +35,7 @@ const TableSearch: FC<TableSearchProps> = ({
         value={value}
         onChange={(e) => setValue(e.target.value)}
         name="search"
-        id="TableSearchInput"
+        id={id || "TableSearchInput"}
       />
     </div>
   );

--- a/src/ui/Table/TableSearch/TableSearch.types.ts
+++ b/src/ui/Table/TableSearch/TableSearch.types.ts
@@ -1,4 +1,5 @@
 export interface TableSearchProps {
   value: string;
   onChange: (value: string) => void;
+  id?: string;
 }


### PR DESCRIPTION
This PR addresses a code health issue where `TableActions` was being rendered for every filterable column, causing multiple action bars to appear. 

Changes:
- **`src/ui/Table/Table.tsx`**: 
  - Extracted `TableActions` from the loop.
  - Renamed `Filter` component to `ColumnFilter`.
  - Wrapped `TableActions` and filters in a flex container for proper layout.
- **`src/ui/Table/TableSearch/TableSearch.tsx` & `.types.ts`**:
  - Added `id` prop to support unique input IDs.
- **`src/ui/Table/Table.test.tsx`**:
  - Added a test case to ensure `TableActions` is rendered exactly once and `TableSearch` is rendered for each filterable column.

Verified with `vitest` and manual frontend verification using Playwright.

---
*PR created automatically by Jules for task [13621730528967952700](https://jules.google.com/task/13621730528967952700) started by @maarconte*