### PR TITLE
⚡ Optimize bulk question deletion with Firestore batch writes

### DIFF
--- a/src/ui/Table/TableActions/TableActions.tsx
+++ b/src/ui/Table/TableActions/TableActions.tsx
@@ -34,19 +34,17 @@ const TableActions: React.FC<TableActionsProps> = ({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const { handleAdd } = useAddDoc("questions");
-  const { handleDelete } = useDeleteDoc("questions");
-  const { questions, refetch } = useQuestionsStore();
+  const { handleDelete, handleDeleteBatch } = useDeleteDoc("questions");
+  const { questions } = useQuestionsStore();
   const handleDeleteAll = () => {
     if (!selectedQuestions || selectedQuestions.length === 0) return;
     if (!setSelectedQuestions || !setIsSelectAll || !setIsSelectNone) return;
 
-    selectedQuestions.forEach((question: Question) => {
-      handleDelete(question.id);
-    });
+    const ids = selectedQuestions.map((question) => question.id);
+    handleDeleteBatch(ids);
     setSelectedQuestions([]);
     setIsSelectAll(false);
     setIsSelectNone(false);
-    refetch();
   };
 
   const handleFileUpload = (file: any) => {
@@ -166,7 +164,6 @@ const TableActions: React.FC<TableActionsProps> = ({
               setIsSelectNone(false);
             }
             setIsDeleteModalOpen(false);
-            refetch();
           }}
           labelOnConfirm="Delete"
           onClose={() => setIsDeleteModalOpen(false)}

--- a/src/utils/hooks/index.tsx
+++ b/src/utils/hooks/index.tsx
@@ -9,6 +9,7 @@ import {
   getFirestore,
   serverTimestamp,
   updateDoc,
+  writeBatch,
 } from "firebase/firestore";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -139,11 +140,44 @@ export function useDeleteDoc(collectionName: string) {
     },
   });
 
+  const deleteBatchMutation = useMutation({
+    mutationFn: async (docIds: string[]) => {
+      const chunkSize = 500;
+      const chunks = [];
+      for (let i = 0; i < docIds.length; i += chunkSize) {
+        chunks.push(docIds.slice(i, i + chunkSize));
+      }
+
+      const promises = chunks.map(async (chunk) => {
+        const batch = writeBatch(db);
+        chunk.forEach((docId) => {
+          const docRef = doc(db, collectionName, docId);
+          batch.delete(docRef);
+        });
+        return await batch.commit();
+      });
+
+      return await Promise.all(promises);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: collectionQueryKey });
+    },
+  });
+
   const handleDelete = (docId: string) => {
     deleteMutation.mutate(docId);
   };
 
-  return { deleteMutation, handleDelete, isLoading: deleteMutation.isPending };
+  const handleDeleteBatch = (docIds: string[]) => {
+    deleteBatchMutation.mutate(docIds);
+  };
+
+  return {
+    deleteMutation,
+    handleDelete,
+    handleDeleteBatch,
+    isLoading: deleteMutation.isPending || deleteBatchMutation.isPending,
+  };
 }
 
 export function formatTimestamp(timestamp: any, locales: Intl.LocalesArgument) {


### PR DESCRIPTION
- **What:** Replaced N+1 `deleteDoc` calls with `writeBatch` in `TableActions` component and `useDeleteDoc` hook.
- **Why:** To improve performance and reduce the number of write operations to Firestore when deleting multiple questions.
- **Measured Improvement:** Verified via test that `writeBatch` is called once (or per 500 items) instead of `deleteDoc` being called N times. This reduces network round trips and ensures atomicity within batches.

---
*PR created automatically by Jules for task [18439445213354178549](https://jules.google.com/task/18439445213354178549) started by @maarconte*