### PR TITLE
⚡ Improve CSV import performance with batch writes

### DIFF
--- a/src/ui/Table/TableActions/TableActions.tsx
+++ b/src/ui/Table/TableActions/TableActions.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Trash2, Plus } from "lucide-react";
-import { useAddDoc, useDeleteDoc } from "../../../utils/hooks";
+import { useBatchAddDocs, useDeleteDoc } from "../../../utils/hooks";
 
 import Button from "../../Button";
 import { Button_Type } from "../../Button/Button.types";
@@ -33,7 +33,8 @@ const TableActions: React.FC<TableActionsProps> = ({
   const [csvData, setCsvData] = useState([]);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
-  const { handleAdd } = useAddDoc("questions");
+  const { handleBatchAdd, isLoading: isBatchAdding } =
+    useBatchAddDocs("questions");
   const { handleDelete } = useDeleteDoc("questions");
   const { questions, refetch } = useQuestionsStore();
   const handleDeleteAll = () => {
@@ -98,15 +99,14 @@ const TableActions: React.FC<TableActionsProps> = ({
     }
   };
 
-  const addAllQuestions = () => {
+  const addAllQuestions = async () => {
     if (!csvData) return;
     try {
-      csvData?.forEach((question) => {
-        handleAdd(question);
-        setCsvData([]);
-      });
+      await handleBatchAdd(csvData);
+      setCsvData([]);
       toast.success("The questions have been added");
     } catch (error) {
+      console.error(error);
       toast.error(
         "An error occurred while adding the questions. Please try again."
       );
@@ -120,6 +120,8 @@ const TableActions: React.FC<TableActionsProps> = ({
           label={`Add ${csvData.length} questions`}
           onClick={addAllQuestions}
           icon={<Plus size={16} />}
+          disabled={isBatchAdding}
+          isLoader={isBatchAdding}
         />
       )}
       <Button

--- a/src/utils/hooks/index.tsx
+++ b/src/utils/hooks/index.tsx
@@ -9,6 +9,7 @@ import {
   getFirestore,
   serverTimestamp,
   updateDoc,
+  writeBatch,
 } from "firebase/firestore";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -124,6 +125,52 @@ export function useAddDoc(collectionName: string) {
     isLoading: addMutation.isPending,
     isError: addMutation.isError,
     isSuccess: addMutation.isSuccess,
+  };
+}
+
+export function useBatchAddDocs(collectionName: string) {
+  const queryClient = useQueryClient();
+  const collectionQueryKey = ["collection", collectionName];
+
+  const batchAddMutation = useMutation({
+    mutationFn: async (dataList: DocumentData[]) => {
+      const batchSize = 500;
+      const chunks = [];
+
+      for (let i = 0; i < dataList.length; i += batchSize) {
+        chunks.push(dataList.slice(i, i + batchSize));
+      }
+
+      const collectionRef = collection(db, collectionName);
+
+      const commitPromises = chunks.map(async (chunk) => {
+        const batch = writeBatch(db);
+        chunk.forEach((data) => {
+          const docRef = doc(collectionRef);
+          batch.set(docRef, {
+            ...data,
+            createdAt: serverTimestamp(),
+          });
+        });
+        await batch.commit();
+      });
+
+      await Promise.all(commitPromises);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: collectionQueryKey });
+    },
+  });
+
+  const handleBatchAdd = async (dataList: DocumentData[]) => {
+    return await batchAddMutation.mutateAsync(dataList);
+  };
+
+  return {
+    handleBatchAdd,
+    isLoading: batchAddMutation.isPending,
+    isError: batchAddMutation.isError,
+    isSuccess: batchAddMutation.isSuccess,
   };
 }
 

--- a/src/utils/hooks/performance.test.tsx
+++ b/src/utils/hooks/performance.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+import { useAddDoc, useBatchAddDocs } from './index';
+
+// Mock Firestore
+vi.mock('firebase/firestore', () => ({
+  getFirestore: vi.fn(() => ({})),
+  collection: vi.fn(),
+  addDoc: vi.fn(),
+  writeBatch: vi.fn(),
+  doc: vi.fn(),
+  serverTimestamp: vi.fn(() => ({ seconds: Date.now() / 1000 })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe('Performance Benchmark', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('current_implementation_benchmark: N+1 writes', async () => {
+    const { addDoc } = await import('firebase/firestore');
+    vi.mocked(addDoc).mockResolvedValue({ id: 'new-id' } as any);
+
+    const { result } = renderHook(() => useAddDoc('questions'), {
+      wrapper: createWrapper(),
+    });
+
+    const items = Array.from({ length: 100 }, (_, i) => ({ title: `Question ${i}` }));
+
+    // Simulate the current implementation loop
+    const promises = items.map(item => result.current.handleAdd(item));
+    await Promise.all(promises);
+
+    expect(addDoc).toHaveBeenCalledTimes(100);
+  });
+
+  it('batch_implementation_benchmark: 1 write per 500 items', async () => {
+    const { writeBatch } = await import('firebase/firestore');
+    const mockBatch = {
+      set: vi.fn(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(writeBatch).mockReturnValue(mockBatch as any);
+
+    const { result } = renderHook(() => useBatchAddDocs('questions'), {
+      wrapper: createWrapper(),
+    });
+
+    const items = Array.from({ length: 100 }, (_, i) => ({ title: `Question ${i}` }));
+
+    await result.current.handleBatchAdd(items);
+
+    expect(writeBatch).toHaveBeenCalledTimes(1);
+    expect(mockBatch.commit).toHaveBeenCalledTimes(1);
+    expect(mockBatch.set).toHaveBeenCalledTimes(100);
+  });
+
+  it('batch_implementation_benchmark: handles > 500 items (chunking)', async () => {
+    const { writeBatch } = await import('firebase/firestore');
+    const mockBatch = {
+      set: vi.fn(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(writeBatch).mockReturnValue(mockBatch as any);
+
+    const { result } = renderHook(() => useBatchAddDocs('questions'), {
+      wrapper: createWrapper(),
+    });
+
+    const items = Array.from({ length: 600 }, (_, i) => ({ title: `Question ${i}` }));
+
+    await result.current.handleBatchAdd(items);
+
+    expect(writeBatch).toHaveBeenCalledTimes(2); // 2 batches
+    expect(mockBatch.commit).toHaveBeenCalledTimes(2);
+    expect(mockBatch.set).toHaveBeenCalledTimes(600);
+  });
+});


### PR DESCRIPTION
Implemented a performance optimization for bulk question import in `TableActions`.
- Created a new hook `useBatchAddDocs` that uses Firestore `writeBatch` to group writes into chunks of 500.
- Replaced the iterative `addDoc` loop in `TableActions` with the new batch hook.
- Added a loading state to the "Add questions" button to prevent double-submission and provide user feedback.
- Added `src/utils/hooks/performance.test.tsx` to benchmark and regression test the batch write logic, confirming reduction from N requests to ceil(N/500) requests.


---
*PR created automatically by Jules for task [824388135264706461](https://jules.google.com/task/824388135264706461) started by @maarconte*