### PR TITLE
⚡ Bolt: Optimize bulk delete with Firestore batching

### DIFF
--- a/src/ui/Table/TableActions/TableActions.tsx
+++ b/src/ui/Table/TableActions/TableActions.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Trash2, Plus } from "lucide-react";
-import { useAddDoc, useDeleteDoc } from "../../../utils/hooks";
+import { useAddDoc, useDeleteDoc, useDeleteDocs } from "../../../utils/hooks";
 
 import Button from "../../Button";
 import { Button_Type } from "../../Button/Button.types";
@@ -35,18 +35,17 @@ const TableActions: React.FC<TableActionsProps> = ({
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const { handleAdd } = useAddDoc("questions");
   const { handleDelete } = useDeleteDoc("questions");
+  const { handleDeleteDocs } = useDeleteDocs("questions");
   const { questions, refetch } = useQuestionsStore();
   const handleDeleteAll = () => {
     if (!selectedQuestions || selectedQuestions.length === 0) return;
     if (!setSelectedQuestions || !setIsSelectAll || !setIsSelectNone) return;
 
-    selectedQuestions.forEach((question: Question) => {
-      handleDelete(question.id);
-    });
+    const idsToDelete = selectedQuestions.map((q) => q.id);
+    handleDeleteDocs(idsToDelete);
     setSelectedQuestions([]);
     setIsSelectAll(false);
     setIsSelectNone(false);
-    refetch();
   };
 
   const handleFileUpload = (file: any) => {
@@ -166,7 +165,6 @@ const TableActions: React.FC<TableActionsProps> = ({
               setIsSelectNone(false);
             }
             setIsDeleteModalOpen(false);
-            refetch();
           }}
           labelOnConfirm="Delete"
           onClose={() => setIsDeleteModalOpen(false)}

--- a/src/utils/hooks/index.test.tsx
+++ b/src/utils/hooks/index.test.tsx
@@ -2,7 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode } from 'react';
-import { useFetchFirebase, useAddDoc, useUpdateDoc, useDeleteDoc } from './index';
+import {
+  useFetchFirebase,
+  useAddDoc,
+  useUpdateDoc,
+  useDeleteDoc,
+  useDeleteDocs,
+} from './index';
 
 // Mock Firestore
 vi.mock('firebase/firestore', () => ({
@@ -13,6 +19,10 @@ vi.mock('firebase/firestore', () => ({
   addDoc: vi.fn(),
   updateDoc: vi.fn(),
   deleteDoc: vi.fn(),
+  writeBatch: vi.fn(() => ({
+    delete: vi.fn(),
+    commit: vi.fn(),
+  })),
   doc: vi.fn(),
   serverTimestamp: vi.fn(() => ({ seconds: Date.now() / 1000 })),
 }));
@@ -144,5 +154,52 @@ describe('useDeleteDoc', () => {
     });
 
     expect(deleteDoc).toHaveBeenCalled();
+  });
+});
+
+describe('useDeleteDocs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should delete documents in batch', async () => {
+    const { writeBatch } = await import('firebase/firestore');
+    const mockBatch = {
+      delete: vi.fn(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(writeBatch).mockReturnValue(mockBatch as any);
+
+    const { result } = renderHook(() => useDeleteDocs('questions'), {
+      wrapper: createWrapper(),
+    });
+
+    const docIds = ['id1', 'id2'];
+    await result.current.handleDeleteDocs(docIds);
+
+    expect(writeBatch).toHaveBeenCalled();
+    expect(mockBatch.delete).toHaveBeenCalledTimes(2);
+    expect(mockBatch.commit).toHaveBeenCalled();
+  });
+
+  it('should chunk requests if more than 500 documents', async () => {
+    const { writeBatch } = await import('firebase/firestore');
+    const mockBatch = {
+      delete: vi.fn(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(writeBatch).mockReturnValue(mockBatch as any);
+
+    const { result } = renderHook(() => useDeleteDocs('questions'), {
+      wrapper: createWrapper(),
+    });
+
+    // Create 505 IDs
+    const docIds = Array.from({ length: 505 }, (_, i) => `id${i}`);
+    await result.current.handleDeleteDocs(docIds);
+
+    expect(writeBatch).toHaveBeenCalledTimes(2); // 2 batches
+    expect(mockBatch.delete).toHaveBeenCalledTimes(505);
+    expect(mockBatch.commit).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/utils/hooks/index.tsx
+++ b/src/utils/hooks/index.tsx
@@ -9,6 +9,7 @@ import {
   getFirestore,
   serverTimestamp,
   updateDoc,
+  writeBatch,
 } from "firebase/firestore";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -144,6 +145,44 @@ export function useDeleteDoc(collectionName: string) {
   };
 
   return { deleteMutation, handleDelete, isLoading: deleteMutation.isPending };
+}
+
+export function useDeleteDocs(collectionName: string) {
+  const queryClient = useQueryClient();
+  const collectionQueryKey = ["collection", collectionName];
+
+  const deleteMutation = useMutation({
+    mutationFn: async (docIds: string[]) => {
+      const chunks = [];
+      for (let i = 0; i < docIds.length; i += 500) {
+        chunks.push(docIds.slice(i, i + 500));
+      }
+
+      await Promise.all(
+        chunks.map(async (chunk) => {
+          const batch = writeBatch(db);
+          chunk.forEach((id) => {
+            const docRef = doc(db, collectionName, id);
+            batch.delete(docRef);
+          });
+          await batch.commit();
+        })
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: collectionQueryKey });
+    },
+  });
+
+  const handleDeleteDocs = async (docIds: string[]) => {
+    return await deleteMutation.mutateAsync(docIds);
+  };
+
+  return {
+    deleteMutation,
+    handleDeleteDocs,
+    isLoading: deleteMutation.isPending,
+  };
 }
 
 export function formatTimestamp(timestamp: any, locales: Intl.LocalesArgument) {


### PR DESCRIPTION
💡 What: Implemented `useDeleteDocs` hook using Firestore `writeBatch` and updated `TableActions` to use it.
🎯 Why: Bulk deletion was performing N+1 network requests and N+1 query invalidations, causing significant performance degradation and rate limit risks.
📊 Impact: Reduces N requests to ceil(N/500) requests (usually 1). Eliminates race conditions and redundant refetches.
🔬 Measurement: Verified with unit tests ensuring batch methods are called correctly and chunked.

---
*PR created automatically by Jules for task [11676573605714713092](https://jules.google.com/task/11676573605714713092) started by @maarconte*