### PR TITLE
⚡ Bolt: Memoize TableQuestions columns to prevent full re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - [Memoize react-table columns array]
+**Learning:** React Table (TanStack Table) heavily relies on referential equality for the `columns` definition array. Defining `columns` directly in the component body (without `useMemo`) will cause the table instance to be re-created on every render, leading to significant performance lag especially when rendering many rows or handling typing/filtering interactions.
+**Action:** Always wrap `columns` in `useMemo` when using `@tanstack/react-table` inside a React component. Also be careful to identify all dynamic variables used inside the columns definition to include them in the dependency array. Do not commit `dist/` build artifacts along with the source code changes.

--- a/src/features/admin/components/TableQuestions/TableQuestions.tsx
+++ b/src/features/admin/components/TableQuestions/TableQuestions.tsx
@@ -82,7 +82,14 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
   const [isSelectNone, setIsSelectNone] = useState(false);
   const { handleDelete } = useDeleteDoc("questions");
 
-  const columns = [
+  // select question
+  const handleSelectQuestion = (question: Question) => {
+    setSelectedQuestion(question);
+    setIsModalOpen(true);
+  };
+
+  // ⚡ Bolt: Memoize columns array to prevent re-creating table columns and unnecessary re-renders of the table
+  const columns = useMemo(() => [
     {
       // column for the checkbox to multiselect
       header: "",
@@ -242,13 +249,7 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
       ),
       enableColumnFilter: false,
     },
-  ];
-
-  // select question
-  const handleSelectQuestion = (question: Question) => {
-    setSelectedQuestion(question);
-    setIsModalOpen(true);
-  };
+  ], [selectedQuestions]);
 
   // Pagination
   const [{ pageIndex, pageSize }, setPagination] = useState({


### PR DESCRIPTION
💡 **What:**
Wrapped the `columns` array definition in `src/features/admin/components/TableQuestions/TableQuestions.tsx` inside a `useMemo` hook, with a dependency on `selectedQuestions`. Moved the `handleSelectQuestion` function before `columns` to make it accessible to the memoized hook.

🎯 **Why:** 
The `@tanstack/react-table` library heavily relies on referential equality to avoid unnecessary recalculations and re-renders. Because the `columns` array was previously defined without `useMemo`, it was recreated on every render of the `TableQuestions` component. This forced the table to re-process columns and rows for every state change (e.g., when filtering, typing, or updating selection state), leading to potential UI lag, especially since the table displays 50 questions per page and supports multi-select interactions.

📊 **Impact:** 
Eliminates full table re-renders caused by `columns` reference changes. The table instance will now only recalculate column-related logic when `selectedQuestions` changes, significantly improving responsiveness during search typing, pagination, and modal toggling.

🔬 **Measurement:** 
- The build completes successfully (`npm run build`).
- Existing tests pass (`npm run test -- --run`). 
- Manual verification: Render the `TableQuestions` component, interact with the "Search" input, toggle a checkbox, and open/close a row's action menu to confirm the UI is responsive and no functional regressions occurred.

---
*PR created automatically by Jules for task [11332454129760931980](https://jules.google.com/task/11332454129760931980) started by @maarconte*