### PR TITLE
⚡ Bolt: Optimize Quizz.tsx by replacing useState with useRef for interval timer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-01 - Avoid useState for Tick Timers in Heavy Components
+**Learning:** Using `useState` to track a "time elapsed" value that updates every second via `setInterval` triggers a full component re-render every tick. If the component (`Quizz.tsx`) is heavy and renders many child components (e.g., `QuestionCard`), this severely impacts performance and responsiveness without any visual benefit, since the time might only be used sporadically (like triggering a toast notification on page turn).
+**Action:** Use `useRef` to track elapsed time (or other high-frequency interval values) when the value doesn't need to be rendered continuously on the screen. This allows reading the current value when needed without paying the re-render tax.

--- a/src/pages/Quizz.tsx
+++ b/src/pages/Quizz.tsx
@@ -1,6 +1,6 @@
 import "rsuite/dist/rsuite.min.css";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 
 import { Button } from "../ui";
 import { Button_Style } from "../ui/Button/Button.types";
@@ -20,7 +20,7 @@ export default function Quizz() {
   const [showAnswer, setShowAnswer] = useState(false);
   const [isFinished, setIsFinished] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
-  const [timeSpent, setTimeSpent] = useState(0);
+  const timeSpent = useRef(0);
   const [open, setOpen] = React.useState(false);
   const notificationContent = (questionNumber: number, time: string) => (
     <div className="toast-content">
@@ -35,27 +35,28 @@ export default function Quizz() {
     return "error";
   };
   const notifyTime = () => {
-    if (timeSpent <= 3) return;
+    if (timeSpent.current <= 3) return;
+
+    const toastOptions: any = {
+      position: "bottom-right",
+      autoClose: 3000,
+      hideProgressBar: true,
+      closeOnClick: false,
+      pauseOnHover: true,
+      theme: "colored",
+      draggable: false,
+      closeButton: false,
+      type: toastType(timeSpent.current),
+    };
+
     toast(
-      notificationContent(currentQuestion, formatTime(timeSpent)),
+      notificationContent(currentQuestion, formatTime(timeSpent.current)),
       toastOptions
     );
   };
 
-  const toastOptions: any = {
-    position: "bottom-right",
-    autoClose: 3000,
-    hideProgressBar: true,
-    closeOnClick: false,
-    pauseOnHover: true,
-    theme: "colored",
-    draggable: false,
-    closeButton: false,
-    type: toastType(timeSpent),
-  };
-
   useEffect(() => {
-    setTimeSpent(0);
+    timeSpent.current = 0;
   }, [currentQuestion]);
 
   useEffect(() => {
@@ -63,7 +64,7 @@ export default function Quizz() {
 
     if (!isPaused) {
       intervalId = setInterval(() => {
-        setTimeSpent((prevTime) => prevTime + 1);
+        timeSpent.current += 1;
       }, 1000);
     } else {
       clearInterval(intervalId);


### PR DESCRIPTION
💡 What: Converted `timeSpent` in `src/pages/Quizz.tsx` from `useState` to `useRef`.
🎯 Why: `setInterval` ticked every second, causing massive, unnecessary full-component re-renders of the heavy `Quizz` component (and all its children, like `QuestionCard`), severely impacting performance.
📊 Impact: Eliminates ~60+ unnecessary re-renders per minute per active user during the quiz.
🔬 Measurement: Open React Profiler before and after during a quiz. Observe re-renders stopped firing every second without user input.

---
*PR created automatically by Jules for task [15188441832187383311](https://jules.google.com/task/15188441832187383311) started by @maarconte*