### PR TITLE
⚡ Bolt: Memoize TableQuestions columns to prevent re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Never commit build artifacts
+**Learning:** React Table column structure is computationally expensive to recalculate on each render. Memoizing them (`useMemo` and `useCallback` on handlers) provides a critical performance boost. Building artifacts locally (`dist`) and committing them creates massive bloated diffs in PRs and fails PR reviews.
+**Action:** Always wrap `@tanstack/react-table` columns and their handlers in `useMemo`/`useCallback`. Never commit the `dist` folder. Only commit source files!

--- a/src/features/admin/components/TableQuestions/TableQuestions.tsx
+++ b/src/features/admin/components/TableQuestions/TableQuestions.tsx
@@ -14,7 +14,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { RankingInfo, rankItem } from "@tanstack/match-sorter-utils";
-import { FC, useEffect, useMemo, useState } from "react";
+import { FC, useEffect, useMemo, useState, useCallback } from "react";
 import { Trash2, XCircle, CheckSquare, X, Edit, ToggleRight, Circle } from "lucide-react";
 import { formatTimestamp, useDeleteDoc } from "../../../../utils/hooks";
 
@@ -82,7 +82,13 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
   const [isSelectNone, setIsSelectNone] = useState(false);
   const { handleDelete } = useDeleteDoc("questions");
 
-  const columns = [
+  // select question
+  const handleSelectQuestion = useCallback((question: Question) => {
+    setSelectedQuestion(question);
+    setIsModalOpen(true);
+  }, [setSelectedQuestion, setIsModalOpen]);
+
+  const columns = useMemo(() => [
     {
       // column for the checkbox to multiselect
       header: "",
@@ -242,13 +248,7 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
       ),
       enableColumnFilter: false,
     },
-  ];
-
-  // select question
-  const handleSelectQuestion = (question: Question) => {
-    setSelectedQuestion(question);
-    setIsModalOpen(true);
-  };
+  ], [selectedQuestions, setSelectedQuestions, setIsSelectAll, setIsSelectNone, handleSelectQuestion, setSelectedQuestion, setIsDeleteModalOpen]);
 
   // Pagination
   const [{ pageIndex, pageSize }, setPagination] = useState({


### PR DESCRIPTION
💡 **What:** Wrapped `columns` definition in `useMemo` and its `handleSelectQuestion` callback in `useCallback` in `TableQuestions.tsx`.

🎯 **Why:** The `@tanstack/react-table` columns array was being recreated on every render of `TableQuestions`. This forced the table instance to continuously recalculate its column models and could trigger cascading re-renders across the table component tree. 

📊 **Impact:** Significantly reduces re-renders in the Admin Questions table, making interaction (like sorting, filtering, row selection) noticeably smoother. It turns an $O(N)$ recalculation per render into $O(1)$ unless dependencies explicitly change.

🔬 **Measurement:** Verify by placing a `console.log` inside the `columns` definition (or `fuzzyFilter`) and observing that it no longer spam-logs during unrelated state changes. Test suite also passes indicating no behavioral regressions.

---
*PR created automatically by Jules for task [826055454249901572](https://jules.google.com/task/826055454249901572) started by @maarconte*