### PR TITLE
⚡ Bolt: Memoize TableQuestions configuration

### DIFF
--- a/src/features/admin/components/TableQuestions/TableQuestions.tsx
+++ b/src/features/admin/components/TableQuestions/TableQuestions.tsx
@@ -14,7 +14,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { RankingInfo, rankItem } from "@tanstack/match-sorter-utils";
-import { FC, useEffect, useMemo, useState } from "react";
+import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import { Trash2, XCircle, CheckSquare, X, Edit, ToggleRight, Circle } from "lucide-react";
 import { formatTimestamp, useDeleteDoc } from "../../../../utils/hooks";
 
@@ -82,7 +82,14 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
   const [isSelectNone, setIsSelectNone] = useState(false);
   const { handleDelete } = useDeleteDoc("questions");
 
-  const columns = [
+  // select question (memoized)
+  const handleSelectQuestion = useCallback((question: Question) => {
+    setSelectedQuestion(question);
+    setIsModalOpen(true);
+  }, []);
+
+  // memoize columns to prevent @tanstack/react-table recalculations
+  const columns = useMemo(() => [
     {
       // column for the checkbox to multiselect
       header: "",
@@ -242,13 +249,7 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
       ),
       enableColumnFilter: false,
     },
-  ];
-
-  // select question
-  const handleSelectQuestion = (question: Question) => {
-    setSelectedQuestion(question);
-    setIsModalOpen(true);
-  };
+  ], [handleSelectQuestion, selectedQuestions]);
 
   // Pagination
   const [{ pageIndex, pageSize }, setPagination] = useState({
@@ -264,14 +265,17 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
     [pageIndex, pageSize]
   );
 
+  // memoize filterFns
+  const filterFns = useMemo(() => ({
+    fuzzy: fuzzyFilter,
+  }), []);
+
   // Table
 
   const table = useReactTable({
     data: allQuestions,
     columns,
-    filterFns: {
-      fuzzy: fuzzyFilter,
-    },
+    filterFns,
     state: {
       pagination,
       sorting,


### PR DESCRIPTION
💡 **What:** Memoized the `columns` array, `filterFns` object, and `handleSelectQuestion` callback in `TableQuestions.tsx` using `useMemo` and `useCallback`.
🎯 **Why:** To prevent `@tanstack/react-table` from performing expensive internal recalculations and forcing unnecessary component re-renders on every render cycle. Unmemoized arrays and objects passed as props to the table hook trigger its internal dependency checks.
📊 **Impact:** Reduces React re-renders and tanstack internal pipeline reconstructions significantly when interacting with the table or its controls.
🔬 **Measurement:** Verify by observing React DevTools Profiler while typing in search inputs or selecting table rows; the `<Table>` and `<TableQuestions>` re-render count and duration should be significantly lower.

---
*PR created automatically by Jules for task [8816975145224309441](https://jules.google.com/task/8816975145224309441) started by @maarconte*