### PR TITLE
⚡ Bolt: Memoize react-table config to prevent unnecessary re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-11-20 - Memoizing react-table v8+ Configurations
+**Learning:** When using `@tanstack/react-table` (v8+), failure to memoize complex configuration objects (like `columns` arrays containing handlers, `filterFns` objects, or handlers passed into column definitions) causes `useReactTable` to recreate the entire table instance and reconstruct internal data pipelines on every single render. This leads to massive performance bottlenecks in list and table rendering.
+**Action:** Always wrap column definitions (`useMemo`), handlers used in cells (`useCallback`), and custom filter/sorting functions (`useMemo` for objects, or declared outside the component) in memoization hooks to guarantee reference stability, being careful to list all accessed state in dependencies.

--- a/src/features/admin/components/TableQuestions/TableQuestions.tsx
+++ b/src/features/admin/components/TableQuestions/TableQuestions.tsx
@@ -14,7 +14,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { RankingInfo, rankItem } from "@tanstack/match-sorter-utils";
-import { FC, useEffect, useMemo, useState } from "react";
+import { FC, useEffect, useCallback, useMemo, useState } from "react";
 import { Trash2, XCircle, CheckSquare, X, Edit, ToggleRight, Circle } from "lucide-react";
 import { formatTimestamp, useDeleteDoc } from "../../../../utils/hooks";
 
@@ -82,7 +82,13 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
   const [isSelectNone, setIsSelectNone] = useState(false);
   const { handleDelete } = useDeleteDoc("questions");
 
-  const columns = [
+  // select question
+  const handleSelectQuestion = useCallback((question: Question) => {
+    setSelectedQuestion(question);
+    setIsModalOpen(true);
+  }, []);
+
+  const columns = useMemo(() => [
     {
       // column for the checkbox to multiselect
       header: "",
@@ -242,13 +248,15 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
       ),
       enableColumnFilter: false,
     },
-  ];
-
-  // select question
-  const handleSelectQuestion = (question: Question) => {
-    setSelectedQuestion(question);
-    setIsModalOpen(true);
-  };
+  ], [
+    selectedQuestions,
+    setSelectedQuestions,
+    setIsSelectAll,
+    setIsSelectNone,
+    setSelectedQuestion,
+    setIsDeleteModalOpen,
+    handleSelectQuestion,
+  ]);
 
   // Pagination
   const [{ pageIndex, pageSize }, setPagination] = useState({
@@ -266,12 +274,14 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
 
   // Table
 
+  const filterFns = useMemo(() => ({
+    fuzzy: fuzzyFilter,
+  }), []);
+
   const table = useReactTable({
     data: allQuestions,
     columns,
-    filterFns: {
-      fuzzy: fuzzyFilter,
-    },
+    filterFns,
     state: {
       pagination,
       sorting,


### PR DESCRIPTION
💡 What: Wrapped `handleSelectQuestion` in `useCallback` and wrapped the `columns` array and `filterFns` object in `useMemo` hooks.

🎯 Why: To solve a critical performance issue in `@tanstack/react-table` (v8) where passing unmemoized configurations causes `useReactTable` to recreate the entire table instance and reconstruct internal pipelines on every component render.

📊 Impact: Significantly reduces the number of full re-renders and computations for the large `TableQuestions` component, making the admin question list much smoother to interact with.

🔬 Measurement: Run the test suite (`npm run test -- --run`) to verify no functionality broke, and observe fewer React Profiler "re-rendered because props changed" warnings during user interaction with table controls.

---
*PR created automatically by Jules for task [9843961259234542545](https://jules.google.com/task/9843961259234542545) started by @maarconte*