### PR TITLE
⚡ Bolt: Optimize timeSpent to prevent full page re-renders every second

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-20 - Interval State React Anti-Pattern
+**Learning:** Using `useState` to track background metrics (like `timeSpent` in `Quizz.tsx` via `setInterval`) causes unnecessary full-tree re-renders every second, even when the value is only read intermittently (e.g., when transitioning to the next question).
+**Action:** Always prefer `useRef` over `useState` for tracking values that update frequently but do not need to trigger visual UI updates immediately.

--- a/src/pages/Quizz.tsx
+++ b/src/pages/Quizz.tsx
@@ -1,6 +1,6 @@
 import "rsuite/dist/rsuite.min.css";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { Button } from "../ui";
 import { Button_Style } from "../ui/Button/Button.types";
@@ -20,7 +20,7 @@ export default function Quizz() {
   const [showAnswer, setShowAnswer] = useState(false);
   const [isFinished, setIsFinished] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
-  const [timeSpent, setTimeSpent] = useState(0);
+  const timeSpentRef = useRef(0);
   const [open, setOpen] = React.useState(false);
   const notificationContent = (questionNumber: number, time: string) => (
     <div className="toast-content">
@@ -35,27 +35,26 @@ export default function Quizz() {
     return "error";
   };
   const notifyTime = () => {
+    const timeSpent = timeSpentRef.current;
     if (timeSpent <= 3) return;
     toast(
       notificationContent(currentQuestion, formatTime(timeSpent)),
-      toastOptions
+      {
+        position: "bottom-right",
+        autoClose: 3000,
+        hideProgressBar: true,
+        closeOnClick: false,
+        pauseOnHover: true,
+        theme: "colored",
+        draggable: false,
+        closeButton: false,
+        type: toastType(timeSpent),
+      }
     );
   };
 
-  const toastOptions: any = {
-    position: "bottom-right",
-    autoClose: 3000,
-    hideProgressBar: true,
-    closeOnClick: false,
-    pauseOnHover: true,
-    theme: "colored",
-    draggable: false,
-    closeButton: false,
-    type: toastType(timeSpent),
-  };
-
   useEffect(() => {
-    setTimeSpent(0);
+    timeSpentRef.current = 0;
   }, [currentQuestion]);
 
   useEffect(() => {
@@ -63,7 +62,7 @@ export default function Quizz() {
 
     if (!isPaused) {
       intervalId = setInterval(() => {
-        setTimeSpent((prevTime) => prevTime + 1);
+        timeSpentRef.current += 1;
       }, 1000);
     } else {
       clearInterval(intervalId);


### PR DESCRIPTION
💡 What:
Refactored `timeSpent` in `src/pages/Quizz.tsx` from `useState` to `useRef`. The timer interval now updates `timeSpentRef.current` directly without triggering React state updates. The value is then safely read from the ref only when needed to generate the toast notification on advancing to the next question.

🎯 Why:
The previous implementation used `useState` inside a `setInterval` that triggered every second. This forced the entire `Quizz` page—including heavily nested components like `QuestionCard`, `Counter`, `Feedback`, and `QuestionNavigation`—to re-render every single second, even though `timeSpent` was not visually displayed anywhere on the screen (it is only shown inside a toast notification at the end of a question). This is a classic React anti-pattern that leads to unnecessary CPU usage, potential memory bloat, and jittery UI performance.

📊 Impact:
Massive reduction in unnecessary component tree re-renders. The `Quizz` page now only re-renders when actual UI state changes (like moving to the next question, opening the drawer, or changing answers), saving 60+ full-page re-renders per minute per user while retaining the exact same timing functionality.

🔬 Measurement:
Start the app locally, open React DevTools Profiler, and record a session while on the quiz page. Before the fix, you will see a commit every second originating from `Quizz`. After the fix, the timeline will be flat, with commits only occurring during actual user interaction. Functionality is verified via `npm test -- --run` which passes completely.

📝 Journal:
Added an entry to `.jules/bolt.md` documenting this `useState` vs `useRef` anti-pattern for background intervals.

---
*PR created automatically by Jules for task [6507647171071431909](https://jules.google.com/task/6507647171071431909) started by @maarconte*