### PR TITLE
⚡ Bolt: Memoize TableQuestions configuration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2024-03-21 - Optimization Log
+
+**Learning:** `useReactTable` instances often re-render excessively when state is updated because non-primitive objects (like column definitions) or array references constantly change, forcing the table to re-compute internally or triggering unwanted effects.
+
+**Action:** Wrap array states in `useMemo` and functions in `useCallback` when passing them into dependencies or props that are deeply watched, particularly `columns` for `@tanstack/react-table`.

--- a/src/features/admin/components/TableQuestions/TableQuestions.tsx
+++ b/src/features/admin/components/TableQuestions/TableQuestions.tsx
@@ -14,7 +14,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { RankingInfo, rankItem } from "@tanstack/match-sorter-utils";
-import { FC, useEffect, useMemo, useState } from "react";
+import { FC, useEffect, useMemo, useState, useCallback } from "react";
 import { Trash2, XCircle, CheckSquare, X, Edit, ToggleRight, Circle } from "lucide-react";
 import { formatTimestamp, useDeleteDoc } from "../../../../utils/hooks";
 
@@ -44,12 +44,13 @@ const fuzzyFilter = (row: any, columnId: any, value: any, addMeta: any) => {
   return itemRank.passed;
 };
 
+const answerTypeOptions = [
+  { value: "TF", label: "True/False", Icon: ToggleRight },
+  { value: "S", label: "Single choice", Icon: Circle },
+  { value: "M", label: "Multiple choice", Icon: CheckSquare },
+];
+
 const getFormatAnswwerType = (answerType: string) => {
-  const answerTypeOptions = [
-    { value: "TF", label: "True/False", Icon: ToggleRight },
-    { value: "S", label: "Single choice", Icon: Circle },
-    { value: "M", label: "Multiple choice", Icon: CheckSquare },
-  ];
   const selectedOption = answerTypeOptions.find(
     (option) => option.value === answerType
   );
@@ -82,7 +83,13 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
   const [isSelectNone, setIsSelectNone] = useState(false);
   const { handleDelete } = useDeleteDoc("questions");
 
-  const columns = [
+  // select question
+  const handleSelectQuestion = useCallback((question: Question) => {
+    setSelectedQuestion(question);
+    setIsModalOpen(true);
+  }, []);
+
+  const columns = useMemo(() => [
     {
       // column for the checkbox to multiselect
       header: "",
@@ -242,13 +249,7 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
       ),
       enableColumnFilter: false,
     },
-  ];
-
-  // select question
-  const handleSelectQuestion = (question: Question) => {
-    setSelectedQuestion(question);
-    setIsModalOpen(true);
-  };
+  ], [selectedQuestions, handleSelectQuestion]);
 
   // Pagination
   const [{ pageIndex, pageSize }, setPagination] = useState({
@@ -266,12 +267,14 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
 
   // Table
 
+  const filterFns = useMemo(() => ({
+    fuzzy: fuzzyFilter,
+  }), []);
+
   const table = useReactTable({
     data: allQuestions,
     columns,
-    filterFns: {
-      fuzzy: fuzzyFilter,
-    },
+    filterFns,
     state: {
       pagination,
       sorting,


### PR DESCRIPTION
💡 What: The `columns` and `filterFns` structures for the react-table instance have been wrapped in `useMemo`, and `handleSelectQuestion` wrapped in `useCallback`. The static `answerTypeOptions` array has been moved outside of the `getFormatAnswwerType` function.
🎯 Why: React-table instances can perform expensive re-initializations and component re-computations when references to objects like `columns` or `filterFns` change on every render.
📊 Impact: Considerably reduces rendering overhead and redundant memory allocations in `TableQuestions`, particularly noticeable when selecting rows or editing data.
🔬 Measurement: Verify using React Developer Tools profiler during list interaction (e.g. checkbox selections). Verify by running unit tests.

---
*PR created automatically by Jules for task [4889880230635797838](https://jules.google.com/task/4889880230635797838) started by @maarconte*