### PR TITLE
⚡ Bolt: Memoize TableQuestions configuration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - [tanstack/react-table: Memoizing configuration objects]
+**Learning:** @tanstack/react-table (v8+) reconstructs its internal pipelines and causes unnecessary re-renders of the entire table if complex configuration objects like `columns` or `filterFns` are not memoized and passed as new references on every render.
+**Action:** Always wrap the `columns` array in `useMemo` (and handlers in `useCallback` if they are dependencies) and configuration objects like `filterFns` in `useMemo` when configuring a `useReactTable` instance.

--- a/src/features/admin/components/TableQuestions/TableQuestions.tsx
+++ b/src/features/admin/components/TableQuestions/TableQuestions.tsx
@@ -14,7 +14,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { RankingInfo, rankItem } from "@tanstack/match-sorter-utils";
-import { FC, useEffect, useMemo, useState } from "react";
+import { FC, useEffect, useCallback, useMemo, useState } from "react";
 import { Trash2, XCircle, CheckSquare, X, Edit, ToggleRight, Circle } from "lucide-react";
 import { formatTimestamp, useDeleteDoc } from "../../../../utils/hooks";
 
@@ -82,7 +82,15 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
   const [isSelectNone, setIsSelectNone] = useState(false);
   const { handleDelete } = useDeleteDoc("questions");
 
-  const columns = [
+  // select question
+  // ⚡ Bolt: Wrapped in useCallback to provide a stable reference for the columns useMemo dependency array.
+  const handleSelectQuestion = useCallback((question: Question) => {
+    setSelectedQuestion(question);
+    setIsModalOpen(true);
+  }, []);
+
+  // ⚡ Bolt: Memoized columns array to prevent @tanstack/react-table from reconstructing internal pipelines on every render.
+  const columns = useMemo(() => [
     {
       // column for the checkbox to multiselect
       header: "",
@@ -242,13 +250,9 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
       ),
       enableColumnFilter: false,
     },
-  ];
+  ], [selectedQuestions, handleSelectQuestion]);
 
-  // select question
-  const handleSelectQuestion = (question: Question) => {
-    setSelectedQuestion(question);
-    setIsModalOpen(true);
-  };
+
 
   // Pagination
   const [{ pageIndex, pageSize }, setPagination] = useState({
@@ -266,12 +270,15 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
 
   // Table
 
+  // ⚡ Bolt: Memoized filterFns object to ensure stable reference for table configuration.
+  const filterFns = useMemo(() => ({
+    fuzzy: fuzzyFilter,
+  }), []);
+
   const table = useReactTable({
     data: allQuestions,
     columns,
-    filterFns: {
-      fuzzy: fuzzyFilter,
-    },
+    filterFns,
     state: {
       pagination,
       sorting,


### PR DESCRIPTION
💡 What: Wrapped `columns` array, `filterFns` object, and `handleSelectQuestion` handler with `useMemo` and `useCallback` respectively in `TableQuestions` component.
🎯 Why: Without memoization, `@tanstack/react-table` configuration objects are recreated on every render, causing the table to reconstruct its internal instance pipelines and unnecessarily re-render all rows.
📊 Impact: Prevents massive redundant calculations and DOM re-renders inside `TableQuestions` when any component state (like filters or modal visibility) changes.
🔬 Measurement: Verify by interacting with filters, checkboxes, or edit modals; React Profiler will show `TableQuestions` updating without cascading re-renders across the entire table.

---
*PR created automatically by Jules for task [5176691845368549731](https://jules.google.com/task/5176691845368549731) started by @maarconte*