### PR TITLE
⚡ Bolt: Batch Firestore Mutations and Prevent N+1

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2025-03-25 - N+1 Firestore Mutations & Loop-Based State Re-renders
+**Learning:** Performing multiple `addDoc` or `deleteDoc` operations inside `forEach` loops directly from components like `TableActions` and `TableQuestions` led to N+1 network requests and significant state thrashing (calling `setCsvData([])` repetitively inside an iterator loop resulting in O(N) re-renders).
+**Action:** Create batch operation hooks (`useAddDocs`, `useDeleteDocs`) encapsulating Firestore's `writeBatch`, breaking larger operations into 500-chunk bundles. Handle state resets globally after the `Promise.all` completion rather than in individual iteration steps.

--- a/src/features/admin/components/TableQuestions/TableQuestions.tsx
+++ b/src/features/admin/components/TableQuestions/TableQuestions.tsx
@@ -16,7 +16,7 @@ import {
 import { RankingInfo, rankItem } from "@tanstack/match-sorter-utils";
 import { FC, useEffect, useMemo, useState } from "react";
 import { Trash2, XCircle, CheckSquare, X, Edit, ToggleRight, Circle } from "lucide-react";
-import { formatTimestamp, useDeleteDoc } from "../../../../utils/hooks";
+import { formatTimestamp, useDeleteDocs } from "../../../../utils/hooks";
 
 import Button from "../../../../ui/Button/Button";
 import Modal from "../../../../ui/Modal/Modal";
@@ -80,7 +80,7 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
   const [selectedQuestions, setSelectedQuestions] = useState<Question[]>([]);
   const [isSelectAll, setIsSelectAll] = useState(false);
   const [isSelectNone, setIsSelectNone] = useState(false);
-  const { handleDelete } = useDeleteDoc("questions");
+  const { handleDeleteDocs } = useDeleteDocs("questions");
 
   const columns = [
     {
@@ -289,10 +289,9 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
     onSortingChange: setSorting,
   });
 
-  const handleDeleteAll = () => {
-    selectedQuestions.forEach((question: Question) => {
-      handleDelete(question.id);
-    });
+  const handleDeleteAll = async () => {
+    const idsToDelete = selectedQuestions.map((q) => q.id);
+    await handleDeleteDocs(idsToDelete);
     setSelectedQuestions([]);
     setIsSelectAll(false);
     setIsSelectNone(false);
@@ -325,7 +324,7 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
           title={`${selectedQuestion ? "Delete question" : "Delete questions"}`}
           onConfirm={() => {
             if (selectedQuestion) {
-              handleDelete(selectedQuestion.id);
+              handleDeleteDocs([selectedQuestion.id]);
               selectedQuestion && setSelectedQuestion(undefined);
             } else {
               handleDeleteAll();

--- a/src/ui/Table/TableActions/TableActions.tsx
+++ b/src/ui/Table/TableActions/TableActions.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Trash2, Plus } from "lucide-react";
-import { useAddDoc, useDeleteDoc } from "../../../utils/hooks";
+import { useAddDocs, useDeleteDocs } from "../../../utils/hooks";
 
 import Button from "../../Button";
 import { Button_Type } from "../../Button/Button.types";
@@ -33,16 +33,16 @@ const TableActions: React.FC<TableActionsProps> = ({
   const [csvData, setCsvData] = useState([]);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
-  const { handleAdd } = useAddDoc("questions");
-  const { handleDelete } = useDeleteDoc("questions");
+  const { handleAddDocs } = useAddDocs("questions");
+  const { handleDeleteDocs } = useDeleteDocs("questions");
   const { questions, refetch } = useQuestionsStore();
-  const handleDeleteAll = () => {
+  const handleDeleteAll = async () => {
     if (!selectedQuestions || selectedQuestions.length === 0) return;
     if (!setSelectedQuestions || !setIsSelectAll || !setIsSelectNone) return;
 
-    selectedQuestions.forEach((question: Question) => {
-      handleDelete(question.id);
-    });
+    const idsToDelete = selectedQuestions.map((q) => q.id);
+    await handleDeleteDocs(idsToDelete);
+
     setSelectedQuestions([]);
     setIsSelectAll(false);
     setIsSelectNone(false);
@@ -98,13 +98,11 @@ const TableActions: React.FC<TableActionsProps> = ({
     }
   };
 
-  const addAllQuestions = () => {
-    if (!csvData) return;
+  const addAllQuestions = async () => {
+    if (!csvData || csvData.length === 0) return;
     try {
-      csvData?.forEach((question) => {
-        handleAdd(question);
-        setCsvData([]);
-      });
+      await handleAddDocs(csvData);
+      setCsvData([]);
       toast.success("The questions have been added");
     } catch (error) {
       toast.error(
@@ -157,7 +155,7 @@ const TableActions: React.FC<TableActionsProps> = ({
               return;
 
             if (selectedQuestion) {
-              handleDelete(selectedQuestion.id);
+              handleDeleteDocs([selectedQuestion.id]);
               selectedQuestion && setSelectedQuestion(undefined);
             } else {
               handleDeleteAll();

--- a/src/utils/hooks/index.test.tsx
+++ b/src/utils/hooks/index.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode } from 'react';
-import { useFetchFirebase, useAddDoc, useUpdateDoc, useDeleteDoc } from './index';
+import { useFetchFirebase, useAddDoc, useUpdateDoc, useDeleteDoc, useAddDocs, useDeleteDocs } from './index';
 
 // Mock Firestore
 vi.mock('firebase/firestore', () => ({
@@ -15,6 +15,11 @@ vi.mock('firebase/firestore', () => ({
   deleteDoc: vi.fn(),
   doc: vi.fn(),
   serverTimestamp: vi.fn(() => ({ seconds: Date.now() / 1000 })),
+  writeBatch: vi.fn(() => ({
+    set: vi.fn(),
+    delete: vi.fn(),
+    commit: vi.fn(),
+  })),
 }));
 
 const createWrapper = () => {
@@ -144,5 +149,74 @@ describe('useDeleteDoc', () => {
     });
 
     expect(deleteDoc).toHaveBeenCalled();
+  });
+});
+
+describe('useAddDocs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should add multiple documents to Firestore using writeBatch and chunking', async () => {
+    const { writeBatch } = await import('firebase/firestore');
+    const commitMock = vi.fn().mockResolvedValue(undefined);
+    const setMock = vi.fn();
+    vi.mocked(writeBatch).mockReturnValue({
+      set: setMock,
+      commit: commitMock,
+      delete: vi.fn(),
+    } as any);
+
+    const { result } = renderHook(() => useAddDocs('questions'), {
+      wrapper: createWrapper(),
+    });
+
+    const newQuestions = Array.from({ length: 501 }, (_, i) => ({ title: `Question ${i}`, answer: 0 }));
+
+    // Use act() for async mutation triggers if using latest React testing tools,
+    // but the original code just calls the function directly.
+    result.current.handleAddDocs(newQuestions);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // Expect 2 chunks (500 and 1)
+    expect(writeBatch).toHaveBeenCalledTimes(2);
+    expect(setMock).toHaveBeenCalledTimes(501);
+    expect(commitMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('useDeleteDocs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should delete multiple documents from Firestore using writeBatch and chunking', async () => {
+    const { writeBatch } = await import('firebase/firestore');
+    const commitMock = vi.fn().mockResolvedValue(undefined);
+    const deleteMock = vi.fn();
+    vi.mocked(writeBatch).mockReturnValue({
+      set: vi.fn(),
+      commit: commitMock,
+      delete: deleteMock,
+    } as any);
+
+    const { result } = renderHook(() => useDeleteDocs('questions'), {
+      wrapper: createWrapper(),
+    });
+
+    const idsToDelete = Array.from({ length: 505 }, (_, i) => `id-${i}`);
+
+    result.current.handleDeleteDocs(idsToDelete);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(writeBatch).toHaveBeenCalledTimes(2);
+    expect(deleteMock).toHaveBeenCalledTimes(505);
+    expect(commitMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/utils/hooks/index.tsx
+++ b/src/utils/hooks/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   DocumentData,
   addDoc,
@@ -9,6 +10,7 @@ import {
   getFirestore,
   serverTimestamp,
   updateDoc,
+  writeBatch,
 } from "firebase/firestore";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -150,4 +152,97 @@ export function formatTimestamp(timestamp: any, locales: Intl.LocalesArgument) {
   if (!timestamp?.seconds) return "";
   const date = new Date(timestamp?.seconds * 1000).toLocaleDateString(locales);
   return date.toLocaleString();
+}
+
+export function useAddDocs(collectionName: string) {
+  const queryClient = useQueryClient();
+  const collectionQueryKey = ["collection", collectionName];
+
+  const addMutation = useMutation({
+    mutationFn: async (newDataList: DocumentData[]) => {
+      const chunks = [];
+      for (let i = 0; i < newDataList.length; i += 500) {
+        chunks.push(newDataList.slice(i, i + 500));
+      }
+
+      await Promise.all(
+        chunks.map(async (chunk) => {
+          const batch = writeBatch(db);
+          chunk.forEach((data) => {
+            const docRef = doc(collection(db, collectionName));
+            batch.set(docRef, {
+              ...data,
+              createdAt: serverTimestamp(),
+            });
+          });
+          return batch.commit();
+        })
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: collectionQueryKey });
+    },
+  });
+
+  const { mutateAsync } = addMutation;
+
+  const handleAddDocs = React.useCallback(
+    async (newDataList: DocumentData[]) => {
+      return await mutateAsync(newDataList);
+    },
+    [mutateAsync]
+  );
+
+  return {
+    addMutation,
+    handleAddDocs,
+    isLoading: addMutation.isPending,
+    isError: addMutation.isError,
+    isSuccess: addMutation.isSuccess,
+  };
+}
+
+export function useDeleteDocs(collectionName: string) {
+  const queryClient = useQueryClient();
+  const collectionQueryKey = ["collection", collectionName];
+
+  const deleteMutation = useMutation({
+    mutationFn: async (docIds: string[]) => {
+      const chunks = [];
+      for (let i = 0; i < docIds.length; i += 500) {
+        chunks.push(docIds.slice(i, i + 500));
+      }
+
+      await Promise.all(
+        chunks.map(async (chunk) => {
+          const batch = writeBatch(db);
+          chunk.forEach((id) => {
+            const docRef = doc(db, collectionName, id);
+            batch.delete(docRef);
+          });
+          return batch.commit();
+        })
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: collectionQueryKey });
+    },
+  });
+
+  const { mutateAsync } = deleteMutation;
+
+  const handleDeleteDocs = React.useCallback(
+    async (docIds: string[]) => {
+      return await mutateAsync(docIds);
+    },
+    [mutateAsync]
+  );
+
+  return {
+    deleteMutation,
+    handleDeleteDocs,
+    isLoading: deleteMutation.isPending,
+    isError: deleteMutation.isError,
+    isSuccess: deleteMutation.isSuccess,
+  };
 }


### PR DESCRIPTION
⚡ Bolt: Batch Firestore Mutations and Prevent N+1

💡 What: Implemented `useAddDocs` and `useDeleteDocs` using `writeBatch` (chunked by 500) and replaced loop-based component mutations.
🎯 Why: Iterating over CSV data or multi-selected rows and calling individual `useAddDoc` / `useDeleteDoc` created N+1 network requests and caused React to re-render N times by hitting `setCsvData([])` synchronously.
📊 Impact: Reduces O(N) network requests to O(N/500). Eliminates N re-renders by batching state transitions globally at the end.
🔬 Measurement: Observe network tab during bulk delete / 500+ row CSV upload; should see max 1 or 2 batch requests. Profile React rendering timeline; component should only re-render once.

---
*PR created automatically by Jules for task [17191400924034671430](https://jules.google.com/task/17191400924034671430) started by @maarconte*