### PR TITLE
⚡ Bolt: Optimize bulk db operations via batched requests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-30 - N+1 Network Request Pattern with React Query in loops
+**Learning:** Performing network requests and query invalidations (like `.forEach(handleDelete)`) causes a severe N+1 issue, launching independent network requests and multiple UI state refetches which slow down the app entirely during bulk operations (like importing CSVs or bulk deleting table rows).
+**Action:** Always write and utilize batched Firestore hooks (`useAddDocs`, `useDeleteDocs`) powered by `writeBatch` when applying mutations to collections. Remember to chunk items into groups of 500 to respect Firestore limitations.

--- a/src/features/admin/components/TableQuestions/TableQuestions.tsx
+++ b/src/features/admin/components/TableQuestions/TableQuestions.tsx
@@ -16,7 +16,7 @@ import {
 import { RankingInfo, rankItem } from "@tanstack/match-sorter-utils";
 import { FC, useEffect, useMemo, useState } from "react";
 import { Trash2, XCircle, CheckSquare, X, Edit, ToggleRight, Circle } from "lucide-react";
-import { formatTimestamp, useDeleteDoc } from "../../../../utils/hooks";
+import { formatTimestamp, useDeleteDoc, useDeleteDocs } from "../../../../utils/hooks";
 
 import Button from "../../../../ui/Button/Button";
 import Modal from "../../../../ui/Modal/Modal";
@@ -81,6 +81,7 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
   const [isSelectAll, setIsSelectAll] = useState(false);
   const [isSelectNone, setIsSelectNone] = useState(false);
   const { handleDelete } = useDeleteDoc("questions");
+  const { handleDeleteDocs } = useDeleteDocs("questions");
 
   const columns = [
     {
@@ -290,9 +291,8 @@ const TableQuestions: FC<TableQuestionsProps> = () => {
   });
 
   const handleDeleteAll = () => {
-    selectedQuestions.forEach((question: Question) => {
-      handleDelete(question.id);
-    });
+    const ids = selectedQuestions.map((question: Question) => question.id);
+    handleDeleteDocs(ids);
     setSelectedQuestions([]);
     setIsSelectAll(false);
     setIsSelectNone(false);

--- a/src/ui/Table/TableActions/TableActions.tsx
+++ b/src/ui/Table/TableActions/TableActions.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Trash2, Plus } from "lucide-react";
-import { useAddDoc, useDeleteDoc } from "../../../utils/hooks";
+import { useAddDoc, useAddDocs, useDeleteDoc, useDeleteDocs } from "../../../utils/hooks";
 
 import Button from "../../Button";
 import { Button_Type } from "../../Button/Button.types";
@@ -34,15 +34,16 @@ const TableActions: React.FC<TableActionsProps> = ({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const { handleAdd } = useAddDoc("questions");
+  const { handleAddDocs } = useAddDocs("questions");
   const { handleDelete } = useDeleteDoc("questions");
+  const { handleDeleteDocs } = useDeleteDocs("questions");
   const { questions, refetch } = useQuestionsStore();
   const handleDeleteAll = () => {
     if (!selectedQuestions || selectedQuestions.length === 0) return;
     if (!setSelectedQuestions || !setIsSelectAll || !setIsSelectNone) return;
 
-    selectedQuestions.forEach((question: Question) => {
-      handleDelete(question.id);
-    });
+    const ids = selectedQuestions.map((question: Question) => question.id);
+    handleDeleteDocs(ids);
     setSelectedQuestions([]);
     setIsSelectAll(false);
     setIsSelectNone(false);
@@ -101,10 +102,8 @@ const TableActions: React.FC<TableActionsProps> = ({
   const addAllQuestions = () => {
     if (!csvData) return;
     try {
-      csvData?.forEach((question) => {
-        handleAdd(question);
-        setCsvData([]);
-      });
+      handleAddDocs(csvData);
+      setCsvData([]);
       toast.success("The questions have been added");
     } catch (error) {
       toast.error(

--- a/src/utils/hooks/index.test.tsx
+++ b/src/utils/hooks/index.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode } from 'react';
-import { useFetchFirebase, useAddDoc, useUpdateDoc, useDeleteDoc } from './index';
+import { useFetchFirebase, useAddDoc, useUpdateDoc, useDeleteDoc, useAddDocs, useDeleteDocs } from './index';
 
 // Mock Firestore
 vi.mock('firebase/firestore', () => ({
@@ -14,6 +14,11 @@ vi.mock('firebase/firestore', () => ({
   updateDoc: vi.fn(),
   deleteDoc: vi.fn(),
   doc: vi.fn(),
+  writeBatch: vi.fn(() => ({
+    set: vi.fn(),
+    delete: vi.fn(),
+    commit: vi.fn().mockResolvedValue(undefined),
+  })),
   serverTimestamp: vi.fn(() => ({ seconds: Date.now() / 1000 })),
 }));
 
@@ -81,6 +86,29 @@ describe('useFetchFirebase', () => {
   });
 });
 
+describe('useAddDocs', () => {
+  it('should add multiple documents to Firestore using writeBatch', async () => {
+    const { writeBatch } = await import('firebase/firestore');
+
+    const { result } = renderHook(() => useAddDocs('questions'), {
+      wrapper: createWrapper(),
+    });
+
+    const newQuestions = [
+      { title: 'New Question 1', answer: 0 },
+      { title: 'New Question 2', answer: 1 },
+    ];
+
+    result.current.handleAddDocs(newQuestions);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(writeBatch).toHaveBeenCalled();
+  });
+});
+
 describe('useAddDoc', () => {
   it('should add a document to Firestore', async () => {
     const { addDoc } = await import('firebase/firestore');
@@ -125,6 +153,24 @@ describe('useUpdateDoc', () => {
     });
 
     expect(updateDoc).toHaveBeenCalled();
+  });
+});
+
+describe('useDeleteDocs', () => {
+  it('should delete multiple documents from Firestore using writeBatch', async () => {
+    const { writeBatch } = await import('firebase/firestore');
+
+    const { result } = renderHook(() => useDeleteDocs('questions'), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.handleDeleteDocs(['test-id-1', 'test-id-2']);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(writeBatch).toHaveBeenCalled();
   });
 });
 

--- a/src/utils/hooks/index.tsx
+++ b/src/utils/hooks/index.tsx
@@ -1,4 +1,5 @@
 import {
+  writeBatch,
   DocumentData,
   addDoc,
   collection,
@@ -144,6 +145,79 @@ export function useDeleteDoc(collectionName: string) {
   };
 
   return { deleteMutation, handleDelete, isLoading: deleteMutation.isPending };
+}
+
+
+export function useAddDocs(collectionName: string) {
+  const queryClient = useQueryClient();
+  const collectionQueryKey = ["collection", collectionName];
+
+  const addMutation = useMutation({
+    mutationFn: async (newDataList: DocumentData[]) => {
+      // Chunk items into groups of 500 to respect Firestore limits
+      const chunkSize = 500;
+      for (let i = 0; i < newDataList.length; i += chunkSize) {
+        const chunk = newDataList.slice(i, i + chunkSize);
+        const batch = writeBatch(db);
+
+        chunk.forEach(newData => {
+          const docRef = doc(collection(db, collectionName));
+          batch.set(docRef, {
+            ...newData,
+            createdAt: serverTimestamp(),
+          });
+        });
+
+        await batch.commit();
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: collectionQueryKey });
+    },
+  });
+
+  const handleAddDocs = async (newDataList: DocumentData[]) => {
+    return await addMutation.mutateAsync(newDataList);
+  };
+
+  return {
+    addMutation,
+    handleAddDocs,
+    isLoading: addMutation.isPending,
+    isError: addMutation.isError,
+    isSuccess: addMutation.isSuccess,
+  };
+}
+
+export function useDeleteDocs(collectionName: string) {
+  const queryClient = useQueryClient();
+  const collectionQueryKey = ["collection", collectionName];
+
+  const deleteMutation = useMutation({
+    mutationFn: async (docIds: string[]) => {
+      // Chunk items into groups of 500 to respect Firestore limits
+      const chunkSize = 500;
+      for (let i = 0; i < docIds.length; i += chunkSize) {
+        const chunk = docIds.slice(i, i + chunkSize);
+        const batch = writeBatch(db);
+
+        chunk.forEach(docId => {
+          batch.delete(doc(db, collectionName, docId));
+        });
+
+        await batch.commit();
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: collectionQueryKey });
+    },
+  });
+
+  const handleDeleteDocs = async (docIds: string[]) => {
+    return await deleteMutation.mutateAsync(docIds);
+  };
+
+  return { deleteMutation, handleDeleteDocs, isLoading: deleteMutation.isPending };
 }
 
 export function formatTimestamp(timestamp: any, locales: Intl.LocalesArgument) {


### PR DESCRIPTION
💡 What: Implemented `useAddDocs` and `useDeleteDocs` which use Firestore `writeBatch` to handle mutations in chunks of 500. Replaced sequential `.forEach` queries in `TableActions.tsx` and `TableQuestions.tsx` with single calls to these hooks.
🎯 Why: Iterating over items and launching independent network calls causes a severe N+1 performance bottleneck, spamming the network tab and causing multiple React state updates and refetches.
📊 Impact: Transforms O(N) network calls and UI re-renders into a single O(1) network batch request (up to 500 items). Massive performance gain when deleting selected table items or adding items via CSV import.
🔬 Measurement: Run a large CSV import. Before, it would fire hundreds of parallel requests, lagging the page. Now, it will send a single batched payload. Same applies for deleting multiple rows.

---
*PR created automatically by Jules for task [11933994228191708544](https://jules.google.com/task/11933994228191708544) started by @maarconte*