### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix API error message information leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Raw Firebase `error.code` and `error.message` strings were concatenated and rendered directly to the user in the `AuthContainer` component upon failed login, registration, or OAuth attempts.
 **Learning:** Returning unhandled upstream error structures back to the client leaks details of internal system libraries (e.g. `firebase/auth`) and creates a user enumeration risk where attackers can verify whether specific email addresses correspond to existing accounts (e.g., distinguishing between `auth/user-not-found` and `auth/wrong-password`).
 **Prevention:** Always catch and handle errors on the client side, then map specific codes to generic error messages for end-users (e.g. "Identifiants invalides.") using centralized error handlers like `src/features/auth/utils/authErrors.ts`.
+## 2025-04-11 - Leaking API Error Messages
+**Vulnerability:** Raw Firebase `error.message` strings were being exposed in thrown errors in `authService.ts`, `roleService.ts`, and `functions/src/index.ts`.
+**Learning:** Exposing raw, third-party error messages in application exceptions can leak details about internal infrastructure, API keys, or system state. Even if these messages are meant for the frontend console, they represent unnecessary information leakage.
+**Prevention:** Always map third-party API errors to safe, generic application-level errors using centralized handlers (like `getAuthErrorMessage`) or generic fallback strings before throwing them up the call stack or returning them via HTTP.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -64,7 +64,7 @@ export const setUserRole = functions.https.onCall(async (data, context) => {
 		functions.logger.error('Erreur lors de l\'attribution du rôle:', error);
 		throw new functions.https.HttpsError(
 			'internal',
-			'Erreur lors de l\'attribution du rôle: ' + error.message
+			'Erreur lors de l\'attribution du rôle'
 		);
 	}
 });

--- a/src/features/auth/api/authService.ts
+++ b/src/features/auth/api/authService.ts
@@ -6,6 +6,7 @@ import {
 	User
 } from 'firebase/auth';
 import { auth } from '../../../lib/firebase';
+import { getAuthErrorMessage } from '../utils/authErrors';
 
 // Magic Link configuration
 const actionCodeSettings = {
@@ -35,7 +36,7 @@ export const authService = {
 			window.localStorage.setItem('emailForSignIn', email);
 		} catch (error: any) {
 			console.error('Error sending Magic Link:', error);
-			throw new Error(error.message || 'Failed to send sign-in link');
+			throw new Error(getAuthErrorMessage(error.code) || 'Failed to send sign-in link');
 		}
 	},
 
@@ -79,7 +80,7 @@ export const authService = {
 				throw new Error('The sign-in link has expired. Please request a new link.');
 			}
 
-			throw new Error(error.message || 'Authentication failed');
+			throw new Error(getAuthErrorMessage(error.code) || 'Authentication failed');
 		}
 	},
 

--- a/src/features/auth/api/roleService.ts
+++ b/src/features/auth/api/roleService.ts
@@ -32,7 +32,7 @@ export const roleService = {
 			return result.data;
 		} catch (error: any) {
 			console.error('Error assigning role:', error);
-			throw new Error(error.message || 'Failed to assign role');
+			throw new Error('Failed to assign role');
 		}
 	},
 };


### PR DESCRIPTION
🎯 **What**
Raw third-party API error messages (like `error.message` from Firebase) were being directly passed into thrown Errors and HTTP exceptions across the authentication and role management services.

⚠️ **Risk**
Exposing raw underlying API error messages to the client application can leak details about internal infrastructure, exact library versions, or specific database constraints. In authentication flows, this can facilitate user enumeration attacks by providing overly specific failure reasons that bypass the application's intended generic messaging.

🛡️ **Solution**
- Updated `sendMagicLink` and `completeMagicLinkSignIn` in `src/features/auth/api/authService.ts` to map `error.code` using the centralized `getAuthErrorMessage` utility, or fallback to safe generic strings.
- Updated `setUserRole` in `src/features/auth/api/roleService.ts` to throw a generic "Failed to assign role" message.
- Updated the Cloud Function `setUserRole` in `functions/src/index.ts` to log the raw error internally but throw a sanitized `HttpsError` without the appended `error.message`.
- Added a Sentinel journal entry documenting this API error leakage pattern.

---
*PR created automatically by Jules for task [13173445648305648313](https://jules.google.com/task/13173445648305648313) started by @maarconte*