### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix raw third-party error message leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Raw Firebase `error.code` and `error.message` strings were concatenated and rendered directly to the user in the `AuthContainer` component upon failed login, registration, or OAuth attempts.
 **Learning:** Returning unhandled upstream error structures back to the client leaks details of internal system libraries (e.g. `firebase/auth`) and creates a user enumeration risk where attackers can verify whether specific email addresses correspond to existing accounts (e.g., distinguishing between `auth/user-not-found` and `auth/wrong-password`).
 **Prevention:** Always catch and handle errors on the client side, then map specific codes to generic error messages for end-users (e.g. "Identifiants invalides.") using centralized error handlers like `src/features/auth/utils/authErrors.ts`.
+
+## 2026-04-14 - Error Message Leakage in Auth Services
+**Vulnerability:** Raw third-party API error messages (like Firebase `error.message`) were being thrown un-sanitized in authentication and role services, which could expose internal system details or enable user enumeration if surfaced to the UI.
+**Learning:** Third-party APIs frequently embed sensitive structural data or precise failure reasons in their error messages. Passing these un-sanitized to the UI layer bypasses the application's secure error masking.
+**Prevention:** Always catch exceptions at the service boundary. Map known error codes to generic, safe error messages using centralized utilities (e.g., `getAuthErrorMessage`), and fallback to static safe strings for unknown errors instead of passing through `error.message`.

--- a/src/features/auth/api/authService.ts
+++ b/src/features/auth/api/authService.ts
@@ -6,6 +6,7 @@ import {
 	User
 } from 'firebase/auth';
 import { auth } from '../../../lib/firebase';
+import { getAuthErrorMessage } from '../utils/authErrors';
 
 // Magic Link configuration
 const actionCodeSettings = {
@@ -35,7 +36,8 @@ export const authService = {
 			window.localStorage.setItem('emailForSignIn', email);
 		} catch (error: any) {
 			console.error('Error sending Magic Link:', error);
-			throw new Error(error.message || 'Failed to send sign-in link');
+			const safeMessage = error?.code ? getAuthErrorMessage(error.code) : 'Failed to send sign-in link';
+			throw new Error(safeMessage);
 		}
 	},
 
@@ -79,7 +81,8 @@ export const authService = {
 				throw new Error('The sign-in link has expired. Please request a new link.');
 			}
 
-			throw new Error(error.message || 'Authentication failed');
+			const safeMessage = error?.code ? getAuthErrorMessage(error.code) : 'Authentication failed';
+			throw new Error(safeMessage);
 		}
 	},
 

--- a/src/features/auth/api/roleService.ts
+++ b/src/features/auth/api/roleService.ts
@@ -32,7 +32,7 @@ export const roleService = {
 			return result.data;
 		} catch (error: any) {
 			console.error('Error assigning role:', error);
-			throw new Error(error.message || 'Failed to assign role');
+			throw new Error('Failed to assign role');
 		}
 	},
 
@@ -51,7 +51,7 @@ export const roleService = {
 			return result.data;
 		} catch (error: any) {
 			console.error('Error deleting user:', error);
-			throw new Error(error.message || 'Failed to delete user');
+			throw new Error('Failed to delete user');
 		}
 	},
 };


### PR DESCRIPTION
🎯 **What**: Third-party API error strings (like Firebase auth `error.message`) were being directly caught and rethrown by `authService.ts` and `roleService.ts`.
⚠️ **Risk**: Passing unsanitized backend or third-party error messages to the frontend can expose details regarding the system's internal structures and state, potentially aiding user enumeration and reconnaissance.
🛡️ **Solution**: Updated catch blocks in the authentication and role services to suppress raw third-party messages. Mapped error codes to generic user-safe strings using the existing `getAuthErrorMessage` helper, and replaced remaining instances with statically defined safe strings. Validated via `npm run test:run` that core logic remains fully functional. Recorded the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [8719787909743281537](https://jules.google.com/task/8719787909743281537) started by @maarconte*