### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent internal error exposure in Cloud Functions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Raw Firebase `error.code` and `error.message` strings were concatenated and rendered directly to the user in the `AuthContainer` component upon failed login, registration, or OAuth attempts.
 **Learning:** Returning unhandled upstream error structures back to the client leaks details of internal system libraries (e.g. `firebase/auth`) and creates a user enumeration risk where attackers can verify whether specific email addresses correspond to existing accounts (e.g., distinguishing between `auth/user-not-found` and `auth/wrong-password`).
 **Prevention:** Always catch and handle errors on the client side, then map specific codes to generic error messages for end-users (e.g. "Identifiants invalides.") using centralized error handlers like `src/features/auth/utils/authErrors.ts`.
+## 2024-05-24 - Leaking Internal Errors in Cloud Functions
+**Vulnerability:** Raw error messages from backend services (like `admin.auth()` or `admin.firestore()`) were caught and directly appended to the error message thrown back to the client via `functions.https.HttpsError`.
+**Learning:** Exposing raw `error.message` strings from backend infrastructure leaks internal details (e.g., database structures, library behavior) and stack traces. This violates the principle of not exposing internal system details to end-users.
+**Prevention:** Cloud functions must securely log the detailed error internally (`functions.logger.error`) but only return generic, sanitized error messages (e.g., "Une erreur interne est survenue") to the client.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -64,7 +64,7 @@ export const setUserRole = functions.https.onCall(async (data, context) => {
 		functions.logger.error('Erreur lors de l\'attribution du rôle:', error);
 		throw new functions.https.HttpsError(
 			'internal',
-			'Erreur lors de l\'attribution du rôle: ' + error.message
+			'Une erreur est survenue lors de l\'attribution du rôle.'
 		);
 	}
 });
@@ -142,7 +142,7 @@ export const deleteUser = functions.https.onCall(async (data, context) => {
 		functions.logger.error('Erreur lors de la suppression de l\'utilisateur:', error);
 		throw new functions.https.HttpsError(
 			'internal',
-			'Erreur lors de la suppression: ' + error.message
+			'Une erreur est survenue lors de la suppression de l\'utilisateur.'
 		);
 	}
 });


### PR DESCRIPTION
🎯 **What:** The Firebase Cloud Functions (`setUserRole` and `deleteUser`) were directly passing raw `error.message` from backend services (like `admin.auth()` or `admin.firestore()`) to the client via `functions.https.HttpsError`.

⚠️ **Risk:** Exposing raw internal backend error messages can leak details about the database structure, library behaviors, and provide stack traces that attackers could use to understand internal architecture.

🛡️ **Solution:** Updated the cloud functions to still log the detailed error internally using `functions.logger.error` for administrative debugging, but to throw a generic, sanitized error message to the client (e.g., "Une erreur est survenue lors de la suppression de l'utilisateur.").

✅ **Verification:**
1. Tests have been run and pass successfully.
2. The change to `functions/src/index.ts` has been built (`npm run build` in functions).
3. The internal log still captures the real error, but the client only receives the sanitized string.

---
*PR created automatically by Jules for task [2409905360769722901](https://jules.google.com/task/2409905360769722901) started by @maarconte*